### PR TITLE
⚠️   Fix NPM - Add submodules contracts in NPM Package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ typings/
 .node_repl_history
 
 # Output of 'npm pack'
+package/
 *.tgz
 
 # Yarn Integrity file
@@ -129,3 +130,6 @@ java/.idea
 
 # Solidity Flattener
 flat_contracts/
+
+# Mac
+.DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -2,8 +2,8 @@
 .idea
 .vscode
 
-submodules
 contracts/
+
 migrations
 test
 .gitmodules

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
   },
   "files": [
     "contracts/**/*.sol",
+    "submodules/**/*.sol",
     "build/artifacts/**/*.json",
-    "!build/artifacts/contracts/**/*.dbg.json"
+    "!build/artifacts/contracts/**/*.dbg.json",
+    "!submodules/ERC725/implementations/node_modules/**/*"
   ],
   "scripts": {
     "test": "NODE_NO_WARNINGS=1 jest",


### PR DESCRIPTION
# What does this PR introduce?

✅  **Make Solidity contracts from the npm package usable**.

## Problem encountered

In the 0.2.2 release from npm, only the contract ABIs (as JSON files) can be used.

❌  **The `*.solc` Solidity contracts _(eg: `UniversalProfile.sol`) are_ unusable**. They cannot be imported, because they expect to import contracts from `submodules/ERC725/implementations` and the /submodules folder is not present in the npm package.

The following error occurs when trying to compile a contract that import from the `@lukso/universal-profile-smartcontracts` npm package.

```bash
Error HH404: File ../submodules/ERC725/implementations/contracts/ERC725/ERC725AccountCore.sol, imported from @lukso/universalprofile-smart-contracts/contracts/UniversalProfileCore.sol, not found.
```

## Solution proposed

- ➕   Add the solidity contracts from the `submodules/` folder in the npm package build.
-  :no_entry_sign:  ignore dependencies from the submodules, to keep package size small (`submodules/ERC725/implementations/node_modules/`)

### Steps to reproduce

1. Create a sample project with truffle or hardhat

```
mkdir myUP
cd myUp
npm init --yes
npm install --save-dev hardhat
npx hardhat
```

2. Install the lukso smart contracts from the npm package:

```bash
npm install 
```

3. Create a smart contract that use one of the contracts from `@lukso/universal-profiles-smartcontracts` (for instance `UniversalProfile.sol`).

```solidity
//SPDX-License-Identifier: Unlicense
pragma solidity ^0.8.0;

import "@lukso/universalprofile-smart-contracts/contracts/UniversalProfile.sol";

contract MyUP is UniversalProfile {
    
}
```

4. Compile the contracts

```bash
npx hardhat compile --force
```