### PR TITLE
Trigger MythX CI manually only

### DIFF
--- a/.github/workflows/mythx-analysis.yml
+++ b/.github/workflows/mythx-analysis.yml
@@ -5,12 +5,6 @@
 
 name: Mythx Security Analysis
 on:
-  pull_request:
-    branches:
-      - "main"
-      - "develop"
-
-  # Enable manual trigger on this workflow
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
MythX CI keeps running on every new commit made to a PR.

It sometimes fail, and make the whole PR look like it is failing, although all the tests + linter checks pass successfully.

I suggest we just add it to be run manually for now, and we change the CI based on what comes out of the discussion in PR #50 