### PR TITLE
Improve iOS artifacts build + add artifacts for Mintable LSP7 / 8

### DIFF
--- a/.github/workflows/publish-ios-artifacts.yml
+++ b/.github/workflows/publish-ios-artifacts.yml
@@ -28,14 +28,11 @@ jobs:
       - if: steps.check.outputs.changed == 'true'
         run: npm ci
 
-      - name: Build contracts ABIs
-        run: npm run build --if-present
-
       - name: Write ABIs for iOS in Swift file
         if: steps.check.outputs.changed == 'true'
         run: |
           mkdir ios
-          node make-ios.js
+          npx hardhat run make-ios.js
 
       - name: Push latest iOS artifacts to 'universalprofile-ios-sdk' repo
         if: steps.check.outputs.changed == 'true'

--- a/.mythx.yml
+++ b/.mythx.yml
@@ -10,6 +10,7 @@ analyze:
   group-name: "@lukso/lsp-universalprofile-smart-contracts"
   solc: 0.8.7
   remappings:
+    - "@erc725/smart-contracts/=node_modules/@erc725/smart-contracts/"
     - "@openzeppelin/=node_modules/@openzeppelin/"
     - "solidity-bytes-utils/=node_modules/solidity-bytes-utils/"
   targets:

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -55,19 +55,15 @@ const config: HardhatUserConfig = {
       "UniversalProfile",
       "LSP6KeyManager",
       "LSP1UniversalReceiverDelegate",
-      "LSP7DigitalAsset",
-      "LSP7CappedSupply",
-      "LSP8IdentifiableDigitalAsset",
-      "LSP8CappedSupply",
+      "LSP7Mintable",
+      "LSP8Mintable",
       // Proxy version
       // ------------------
       "UniversalProfileInit",
       "LSP6KeyManagerInit",
       "LSP1UniversalReceiverDelegateInit",
-      "LSP7DigitalAssetInit",
-      "LSP7CappedSupplyInit",
-      "LSP8IdentifiableDigitalAssetInit",
-      "LSP8CappedSupplyInit",
+      "LSP7MintableInit",
+      "LSP8MintableInit",
       // ERC Compatible tokens
       // ------------------
       "LSP7CompatibilityForERC20",

--- a/make-ios.js
+++ b/make-ios.js
@@ -1,87 +1,29 @@
-"use strict";
-
 const fs = require("fs");
+const hre = require("hardhat");
 
-// Standard version
-// ------------------
-const UniversalProfile = fs.readFileSync(
-  "./artifacts/contracts/UniversalProfile.sol/UniversalProfile.json"
-);
-const KeyManager = fs.readFileSync(
-  "./artifacts/contracts/LSP6KeyManager/LSP6KeyManager.sol/LSP6KeyManager.json"
-);
-const UniversalReceiverDelegate = fs.readFileSync(
-  "./artifacts/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegate.sol/LSP1UniversalReceiverDelegate.json"
-);
-const LSP7 = fs.readFileSync(
-  "./artifacts/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol/LSP7DigitalAsset.json"
-);
-const LSP7CappedSupply = fs.readFileSync(
-  "./artifacts/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol/LSP7CappedSupply.json"
-);
-const LSP8 = fs.readFileSync(
-  "./artifacts/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol/LSP8IdentifiableDigitalAsset.json"
-);
-const LSP8CappedSupply = fs.readFileSync(
-  "./artifacts/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol/LSP8CappedSupply.json"
-);
+// first generate the JSON artifacts to have a folder "./artifacts/{Contract}.json"
+hre.run("prepare-package").then(() => {
+  const swiftAbis = {};
 
-const UniversalProfile_ABI = JSON.parse(UniversalProfile).abi;
-const KeyManager_ABI = JSON.parse(KeyManager).abi;
-const UniversalReceiverDelegate_ABI = JSON.parse(UniversalReceiverDelegate).abi;
-const LSP7_ABI = JSON.parse(LSP7).abi;
-const LSP7CappedSupply_ABI = JSON.parse(LSP7CappedSupply).abi;
-const LSP8_ABI = JSON.parse(LSP8).abi;
-const LSP8CappedSupply_ABI = JSON.parse(LSP8CappedSupply).abi;
+  // 1. for each contract included in the package
+  const contracts = hre.config.packager.contracts;
 
-// Proxy version
-// ------------------
-const UniversalProfileInit = fs.readFileSync(
-  "./artifacts/contracts/UniversalProfileInit.sol/UniversalProfileInit.json"
-);
-const KeyManagerInit = fs.readFileSync(
-  "./artifacts/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol/LSP6KeyManagerInit.json"
-);
-const UniversalReceiverDelegateInit = fs.readFileSync(
-  "./artifacts/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateInit.sol/LSP1UniversalReceiverDelegateInit.json"
-);
-const LSP7Init = fs.readFileSync(
-  "./artifacts/contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol/LSP7DigitalAssetInit.json"
-);
-const LSP7CappedSupplyInit = fs.readFileSync(
-  "./artifacts/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInit.sol/LSP7CappedSupplyInit.json"
-);
-const LSP8Init = fs.readFileSync(
-  "./artifacts/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInit.sol/LSP8IdentifiableDigitalAssetInit.json"
-);
-const LSP8CappedSupplyInit = fs.readFileSync(
-  "./artifacts/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInit.sol/LSP8CappedSupplyInit.json"
-);
+  for (const contract of contracts) {
+    //  1.1 read the artifact file (one at a time)
+    let artifact = fs.readFileSync(`./artifacts/${contract}.json`);
 
-const UniversalProfileInit_ABI = JSON.parse(UniversalProfileInit).abi;
-const KeyManagerInit_ABI = JSON.parse(KeyManagerInit).abi;
-const UniversalReceiverDelegateInit_ABI = JSON.parse(UniversalReceiverDelegateInit).abi;
-const LSP7Init_ABI = JSON.parse(LSP7Init).abi;
-const LSP7CappedSupplyInit_ABI = JSON.parse(LSP7CappedSupplyInit).abi;
-const LSP8Init_ABI = JSON.parse(LSP8Init).abi;
-const LSP8CappedSupplyInit_ABI = JSON.parse(LSP8CappedSupplyInit).abi;
+    //  1.2 get the abi field in the JSON file
+    let abi = JSON.parse(artifact).abi;
 
-// ERC Compatible tokens
-// ------------------------
-const LSP7CompatibilityForERC20 = fs.readFileSync(
-  "./artifacts/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.sol/LSP7CompatibilityForERC20.json"
-);
-const LSP8CompatibilityForERC721 = fs.readFileSync(
-  "./artifacts/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721.sol/LSP8CompatibilityForERC721.json"
-);
+    //  1.3 save each abi as a string in a list object
+    //  escaping double quotes '\\"', so that it can be parsed correctly
+    swiftAbis[contract] = JSON.stringify(abi).replace(/"/g, '\\"');
+  }
 
-const LSP7CompatibilityForERC20_ABI = JSON.parse(LSP7CompatibilityForERC20).abi;
-const LSP8CompatibilityForERC721_ABI = JSON.parse(LSP8CompatibilityForERC721).abi;
+  let upSwiftFile = "./ios/UPContractsAbi.swift";
 
-let upSwiftFile = "./ios/UPContractsAbi.swift";
-
-let fileContents = `
-//
+  // 2. add each swift abi in the file content,
+  let swiftFileContent = `//
 //  UPContractsAbi.swift
 //  universalprofile-ios-sdk
 //
@@ -92,82 +34,31 @@ import Foundation
 
 public final class UPContractsAbi {
 
-    // Standard Version
-    // ------------------
+   `;
 
-    public static let UNIVERSAL_PROFILE_ABI = "${JSON.stringify(UniversalProfile_ABI).replace(
-      /"/g,
-      '\\"'
-    )}"
+  const getAbisAsArray = () => {
+    let body = [];
+    for (const [key, value] of Object.entries(swiftAbis)) {
+      body.push(`public static let ${key}_ABI = "${value}"`);
+    }
+    return body;
+  };
 
-    public static let LSP6_KEY_MANAGER_ABI = "${JSON.stringify(KeyManager_ABI).replace(
-      /"/g,
-      '\\"'
-    )}"
+  let variablesList = getAbisAsArray();
+
+  let swiftFileEnd = `
     
-    public static let LSP1_UNIVERSAL_RECEIVER_DELEGATE_ABI = "${JSON.stringify(
-      UniversalReceiverDelegate_ABI
-    ).replace(/"/g, '\\"')}"
+} // end of lsp-universalprofile-smart-contract abis
+  `;
 
-    public static let LSP7_DIGITAL_ASSET_ABI = "${JSON.stringify(LSP7_ABI).replace(
-      /"/g,
-      '\\"'
-    )}"    
-    public static let LSP7_CAPPED_SUPPLY_ABI = "${JSON.stringify(LSP7CappedSupply_ABI).replace(
-      /"/g,
-      '\\"'
-    )}"    
-    public static let LSP8_IDENTIFIABLE_DIGITAL_ASSET_ABI = "${JSON.stringify(LSP8_ABI).replace(
-      /"/g,
-      '\\"'
-    )}"    
-    public static let LSP8_CAPPED_SUPPLY_ABI = "${JSON.stringify(LSP8CappedSupply_ABI).replace(
-      /"/g,
-      '\\"'
-    )}"    
+  swiftFileContent = swiftFileContent.concat(variablesList.join("\n\n   "));
+  swiftFileContent = swiftFileContent.concat(swiftFileEnd);
 
-    // Proxy version
-    // ------------------
-
-    public static let UNIVERSAL_PROFILE_INIT_ABI = "${JSON.stringify(
-      UniversalProfileInit_ABI
-    ).replace(/"/g, '\\"')}"    
-
-    public static let LSP6_KEY_MANAGER_INIT_ABI = "${JSON.stringify(KeyManagerInit_ABI).replace(
-      /"/g,
-      '\\"'
-    )}" 
-    
-    public static let LSP1_UNIVERSAL_RECEIVER_DELEGATE_INIT_ABI = "${JSON.stringify(
-      UniversalReceiverDelegateInit_ABI
-    ).replace(/"/g, '\\"')}"
-
-    public static let LSP7_DIGITAL_ASSET_INIT_ABI = "${JSON.stringify(LSP7Init_ABI).replace(
-      /"/g,
-      '\\"'
-    )}"    
-    public static let LSP7_CAPPED_SUPPLY_INIT_ABI = "${JSON.stringify(
-      LSP7CappedSupplyInit_ABI
-    ).replace(/"/g, '\\"')}"  
-
-    public static let LSP8_IDENTIFIABLE_DIGITAL_ASSET_INIT_ABI = "${JSON.stringify(
-      LSP8Init_ABI
-    ).replace(/"/g, '\\"')}"    
-    public static let LSP8_CAPPED_SUPPLY_INIT_ABI = "${JSON.stringify(
-      LSP8CappedSupplyInit_ABI
-    ).replace(/"/g, '\\"')}"    
-        
-    // ERC Compatible tokens
-    // ------------------------
-    public static let LSP7_COMPATIBILITY_FOR_ERC20_ABI = "${JSON.stringify(
-      LSP7CompatibilityForERC20_ABI
-    ).replace(/"/g, '\\"')}"    
-    public static let LSP8_COMPATIBILITY_FOR_RC721_ABI = "${JSON.stringify(
-      LSP8CompatibilityForERC721_ABI
-    ).replace(/"/g, '\\"')}"    
-}
-`;
-
-fs.appendFile(upSwiftFile, fileContents, (err) => {
-  if (err) console.log(err);
+  // 3. finally, write the content inside the file
+  fs.appendFile(upSwiftFile, swiftFileContent, (err) => {
+    if (err) console.log(err);
+    console.log(
+      `\u2713 \uF8FF Successfully created Swift contract ABIs (see file: ${upSwiftFile})`
+    );
+  });
 });

--- a/make-ios.js
+++ b/make-ios.js
@@ -48,7 +48,7 @@ public final class UPContractsAbi {
 
   let swiftFileEnd = `
     
-} // end of lsp-universalprofile-smart-contract abis
+}
   `;
 
   swiftFileContent = swiftFileContent.concat(variablesList.join("\n\n   "));

--- a/make-jar.sh
+++ b/make-jar.sh
@@ -18,17 +18,13 @@ solc --abi --bin \
     contracts/UniversalProfile.sol \
     contracts/LSP6KeyManager/LSP6KeyManager.sol \
     contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegate.sol \
-    contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol \
-    contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol \
-    contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol \
-    contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol \
+    contracts/LSP7DigitalAsset/extensions/LSP7Mintable.sol.sol \
+    contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Mintable.sol.sol \
     contracts/UniversalProfileInit.sol \
     contracts/LSP6KeyManager/LSP6KeyManagerInit.sol \
     contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateInit.sol \
-    contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol \
-    contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInit.sol \
-    contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInit.sol \
-    contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInit.sol \
+    contracts/LSP7DigitalAsset/extensions/LSP7MintableInit.sol.sol \
+    contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8MintableInit.sol.sol \
     contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.sol \
     contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721.sol \
     -o ./output/
@@ -37,17 +33,13 @@ FILES=(
     UniversalProfile
     LSP6KeyManager
     LSP1UniversalReceiverDelegate
-    LSP7DigitalAsset
-    LSP7CappedSupply
-    LSP8IdentifiableDigitalAsset
-    LSP8CappedSupply
+    LSP7Mintable
+    LSP8Mintable
     UniversalProfileInit
     LSP6KeyManagerInit
     LSP1UniversalReceiverDelegateInit
-    LSP7DigitalAssetInit
-    LSP7CappedSupplyInit
-    LSP8IdentifiableDigitalAssetInit
-    LSP8CappedSupplyInit
+    LSP7MintableInit
+    LSP8MintableInit
     LSP7CompatibilityForERC20
     LSP8CompatibilityForERC721
 )


### PR DESCRIPTION
**NB:** this PR can be merged after #61 has been merged

# What does this PR introduce?

- removed previous versions of LSP7/8 artifacts (including their extensions), as they cannot be used (cannot mint)
- added `LSP7Mintable` and `LSP8Mintable` in npm, android and ios artifacts
- improve iOS build to use artifacts specified in `hardhat.config.ts`
- added remapping for `@erc725/smart-contracts/` in mythx config file 