### PR TITLE
feat: `ADDPERMISSIONS` + refactor LSP6Keymanager internal functions names & logic

### DIFF
--- a/contracts/Helpers/KeyManager/KeyManagerHelper.sol
+++ b/contracts/Helpers/KeyManager/KeyManagerHelper.sol
@@ -7,6 +7,8 @@ import "../../LSP6KeyManager/LSP6KeyManager.sol";
  * Helper contract to test internal functions of the KeyManager
  */
 contract KeyManagerHelper is LSP6KeyManager {
+    using ERC725Utils for ERC725Y;
+
     /* solhint-disable no-empty-blocks */
     constructor(address _account) LSP6KeyManager(_account) {}
 
@@ -19,11 +21,23 @@ contract KeyManagerHelper is LSP6KeyManager {
     }
 
     function getAllowedAddresses(address _sender) public view returns (bytes memory) {
-        return super._getAllowedAddresses(_sender);
+        return
+            ERC725Y(account).getDataSingle(
+                LSP2Utils.generateBytes20MappingWithGroupingKey(
+                    _ADDRESS_ALLOWEDADDRESSES,
+                    bytes20(_sender)
+                )
+            );
     }
 
     function getAllowedFunctions(address _sender) public view returns (bytes memory) {
-        return super._getAllowedFunctions(_sender);
+        return
+            ERC725Y(account).getDataSingle(
+                LSP2Utils.generateBytes20MappingWithGroupingKey(
+                    _ADDRESS_ALLOWEDFUNCTIONS,
+                    bytes20(_sender)
+                )
+            );
     }
 
     function isAllowedAddress(address _sender, address _recipient) public view returns (bool) {

--- a/contracts/Helpers/KeyManager/KeyManagerHelper.sol
+++ b/contracts/Helpers/KeyManager/KeyManagerHelper.sol
@@ -35,6 +35,6 @@ contract KeyManagerHelper is LSP6KeyManager {
     }
 
     function isAllowed(bytes32 _permission, bytes32 _addressPermission) public pure returns (bool) {
-        return super._isAllowed(_permission, _addressPermission);
+        return super._hasPermission(_permission, _addressPermission);
     }
 }

--- a/contracts/Helpers/KeyManager/KeyManagerHelper.sol
+++ b/contracts/Helpers/KeyManager/KeyManagerHelper.sol
@@ -41,11 +41,11 @@ contract KeyManagerHelper is LSP6KeyManager {
     }
 
     function verifyIfAllowedAddress(address _sender, address _recipient) public view {
-        super._verifyIfAllowedAddress(_sender, _recipient);
+        super._verifyAllowedAddress(_sender, _recipient);
     }
 
     function verifyIfAllowedFunction(address _sender, bytes4 _function) public view {
-        super._verifyIfAllowedFunction(_sender, _function);
+        super._verifyAllowedFunction(_sender, _function);
     }
 
     function isAllowed(bytes32 _permission, bytes32 _addressPermission) public pure returns (bool) {

--- a/contracts/Helpers/KeyManager/KeyManagerHelper.sol
+++ b/contracts/Helpers/KeyManager/KeyManagerHelper.sol
@@ -40,14 +40,12 @@ contract KeyManagerHelper is LSP6KeyManager {
             );
     }
 
-    function isAllowedAddress(address _sender, address _recipient) public view returns (bool) {
+    function verifyIfAllowedAddress(address _sender, address _recipient) public view {
         super._verifyIfAllowedAddress(_sender, _recipient);
-        return true;
     }
 
-    function isAllowedFunction(address _sender, bytes4 _function) public view returns (bool) {
+    function verifyIfAllowedFunction(address _sender, bytes4 _function) public view {
         super._verifyIfAllowedFunction(_sender, _function);
-        return true;
     }
 
     function isAllowed(bytes32 _permission, bytes32 _addressPermission) public pure returns (bool) {

--- a/contracts/Helpers/KeyManager/KeyManagerHelper.sol
+++ b/contracts/Helpers/KeyManager/KeyManagerHelper.sol
@@ -17,7 +17,7 @@ contract KeyManagerHelper is LSP6KeyManager {
     }
 
     function getUserPermissions(address _user) public view returns (bytes32) {
-        return super._getUserPermissions(_user);
+        return super._getAddressPermissions(_user);
     }
 
     function getAllowedAddresses(address _sender) public view returns (bytes memory) {
@@ -41,11 +41,13 @@ contract KeyManagerHelper is LSP6KeyManager {
     }
 
     function isAllowedAddress(address _sender, address _recipient) public view returns (bool) {
-        return super._isAllowedAddress(_sender, _recipient);
+        super._verifyIfAllowedAddress(_sender, _recipient);
+        return true;
     }
 
     function isAllowedFunction(address _sender, bytes4 _function) public view returns (bool) {
-        return super._isAllowedFunction(_sender, _function);
+        super._verifyIfAllowedFunction(_sender, _function);
+        return true;
     }
 
     function isAllowed(bytes32 _permission, bytes32 _addressPermission) public pure returns (bool) {

--- a/contracts/Helpers/KeyManager/KeyManagerHelper.sol
+++ b/contracts/Helpers/KeyManager/KeyManagerHelper.sol
@@ -7,12 +7,11 @@ import "../../LSP6KeyManager/LSP6KeyManager.sol";
  * Helper contract to test internal functions of the KeyManager
  */
 contract KeyManagerHelper is LSP6KeyManager {
-
     /* solhint-disable no-empty-blocks */
     constructor(address _account) LSP6KeyManager(_account) {}
 
     function getInterfaceId() public pure returns (bytes4) {
-        return _INTERFACE_ID_LSP6;
+        return _LSP6_INTERFACE_ID;
     }
 
     function getUserPermissions(address _user) public view returns (bytes32) {
@@ -38,5 +37,4 @@ contract KeyManagerHelper is LSP6KeyManager {
     function isAllowed(bytes32 _permission, bytes32 _addressPermission) public pure returns (bool) {
         return super._isAllowed(_permission, _addressPermission);
     }
-
 }

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -1,5 +1,31 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
+// interfaces
+import "./ILSP6KeyManager.sol";
+
 // --- ERC165 interface ids
-bytes4 constant _LSP6_INTERFACE_ID = 0x6f4df48b;
+bytes4 constant _LSP6_INTERFACE_ID = type(ILSP6KeyManager).interfaceId;
+
+/* solhint-disable */
+// PERMISSION KEYS
+// prettier-ignore
+bytes8 constant _SET_PERMISSIONS           = 0x4b80742d00000000; // AddressPermissions:<...>
+bytes12 constant _ADDRESS_PERMISSIONS = 0x4b80742d0000000082ac0000; // AddressPermissions:Permissions:<address> --> bytes32
+bytes12 constant _ADDRESS_ALLOWEDADDRESSES = 0x4b80742d00000000c6dd0000; // AddressPermissions:AllowedAddresses:<address> --> address[]
+bytes12 constant _ADDRESS_ALLOWEDFUNCTIONS = 0x4b80742d000000008efe0000; // AddressPermissions:AllowedFunctions:<address> --> bytes4[]
+bytes12 constant _ADDRESS_ALLOWEDSTANDARDS = 0x4b80742d000000003efa0000; // AddressPermissions:AllowedStandards:<address> --> bytes4[]
+/* solhint-enable */
+
+// PERMISSIONS VALUES
+// prettier-ignore
+bytes32 constant _PERMISSION_CHANGEOWNER       = 0x0000000000000000000000000000000000000000000000000000000000000001; // [240 x 0 bits...] 0000 0000 0000 0001
+bytes32 constant _PERMISSION_CHANGEPERMISSIONS = 0x0000000000000000000000000000000000000000000000000000000000000002; // [      ...      ] .... .... .... 0010
+bytes32 constant _PERMISSION_ADDPERMISSIONS = 0x0000000000000000000000000000000000000000000000000000000000000004; // [      ...      ] .... .... .... 0100
+bytes32 constant _PERMISSION_SETDATA = 0x0000000000000000000000000000000000000000000000000000000000000008; // [      ...      ] .... .... .... 1000
+bytes32 constant _PERMISSION_CALL = 0x0000000000000000000000000000000000000000000000000000000000000010; // [      ...      ] .... .... 0001 ....
+bytes32 constant _PERMISSION_STATICCALL = 0x0000000000000000000000000000000000000000000000000000000000000020; // [      ...      ] .... .... 0010 ....
+bytes32 constant _PERMISSION_DELEGATECALL = 0x0000000000000000000000000000000000000000000000000000000000000040; // [      ...      ] .... .... 0100 ....
+bytes32 constant _PERMISSION_DEPLOY = 0x0000000000000000000000000000000000000000000000000000000000000080; // [      ...      ] .... .... 1000 ....
+bytes32 constant _PERMISSION_TRANSFERVALUE = 0x0000000000000000000000000000000000000000000000000000000000000100; // [      ...      ] .... 0001 .... ....
+bytes32 constant _PERMISSION_SIGN = 0x0000000000000000000000000000000000000000000000000000000000000200; // [      ...      ] .... 0010 .... ....

--- a/contracts/LSP6KeyManager/LSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManager.sol
@@ -5,10 +5,8 @@ pragma solidity ^0.8.6;
 import "./LSP6KeyManagerCore.sol";
 
 contract LSP6KeyManager is LSP6KeyManagerCore {
-
     constructor(address _account) {
         account = ERC725(_account);
-        _registerInterface(_INTERFACE_ID_LSP6);
+        _registerInterface(_LSP6_INTERFACE_ID);
     }
-    
 }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -10,9 +10,9 @@ import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
 import "./ILSP6KeyManager.sol";
 
 // libraries
-import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import "@erc725/smart-contracts/contracts/utils/ERC725Utils.sol";
 import "../Utils/LSP2Utils.sol";
+import "@erc725/smart-contracts/contracts/utils/ERC725Utils.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 // constants
 import "./LSP6Constants.sol";
@@ -24,9 +24,9 @@ import "@erc725/smart-contracts/contracts/constants.sol";
  * @dev all the permissions can be set on the ERC725 Account using `setData(...)` with the keys constants below
  */
 abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
-    using ECDSA for bytes32;
     using LSP2Utils for bytes12;
     using ERC725Utils for ERC725Y;
+    using ECDSA for bytes32;
 
     ERC725 public account;
     mapping(address => mapping(uint256 => uint256)) internal _nonceStore;

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -26,6 +26,7 @@ import "@erc725/smart-contracts/contracts/constants.sol";
 abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
     using ECDSA for bytes32;
     using ERC725Utils for ERC725Y;
+    using LSP2Utils for bytes12;
 
     ERC725 public account;
     mapping(address => mapping(uint256 => uint256)) internal _nonceStore;

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -31,14 +31,6 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
     ERC725 public account;
     mapping(address => mapping(uint256 => uint256)) internal _nonceStore;
 
-    /* solhint-disable */
-    // selectors
-    bytes4 internal immutable _SETDATA_SELECTOR = account.setData.selector; // 0x14a6e293
-    bytes4 internal immutable _EXECUTE_SELECTOR = account.execute.selector; // 0x44c028fe
-    bytes4 internal immutable _TRANSFEROWNERSHIP_SELECTOR = account.transferOwnership.selector; // 0xf2fde38b;
-
-    /* solhint-enable */
-
     /**
      * @dev See {IERC165-supportsInterface}.
      */

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -287,7 +287,8 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
 
             // check if we try to change permissions
             if (bytes8(setDataKey) == _SET_PERMISSIONS) {
-                bool isNewAddress = ERC725Y(account).getDataSingle(setDataKey).length == 0;
+                bool isNewAddress = bytes32(ERC725Y(account).getDataSingle(setDataKey)) ==
+                    bytes32(0);
 
                 isNewAddress
                     ? require(

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -25,7 +25,6 @@ import "@erc725/smart-contracts/contracts/constants.sol";
  */
 abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
     using ECDSA for bytes32;
-    using SafeMath for uint256;
     using ERC725Utils for ERC725Y;
 
     ERC725 public account;

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -203,11 +203,11 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
         bytes32 permissions = _getAddressPermissions(_from);
 
         uint256 keyCount = uint256(bytes32(_data[68:100]));
-        uint256 ptrStart = 100;
+        uint256 pointer = 100;
 
         // loop through the keys
-        for (uint256 ii = 0; ii <= keyCount - 1; ii++) {
-            bytes32 key = bytes32(_data[ptrStart:ptrStart + 32]);
+        for (uint256 ii = 0; ii < keyCount; ii++) {
+            bytes32 key = bytes32(_data[pointer:pointer + 32]);
 
             // check if the key is related to setting permissions
             if (bytes8(key) == _SET_PERMISSIONS) {
@@ -229,8 +229,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
                 );
             }
 
-            // move calldata pointers if not at the end of the list
-            if (ii != keyCount - 1) ptrStart += 32;
+            pointer += 32; // move calldata pointer
         }
     }
 
@@ -291,7 +290,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
 
         address[] memory allowedAddressesList = abi.decode(allowedAddresses, (address[]));
 
-        for (uint256 ii = 0; ii <= allowedAddressesList.length - 1; ii++) {
+        for (uint256 ii = 0; ii < allowedAddressesList.length; ii++) {
             if (_to == allowedAddressesList[ii]) return;
         }
         revert("KeyManager:_verifyAllowedAddress: Not authorized to interact with this address");
@@ -309,7 +308,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
 
         bytes4[] memory allowedFunctionsList = abi.decode(allowedFunctions, (bytes4[]));
 
-        for (uint256 ii = 0; ii <= allowedFunctionsList.length - 1; ii++) {
+        for (uint256 ii = 0; ii < allowedFunctionsList.length; ii++) {
             if (_functionSelector == allowedFunctionsList[ii]) return;
         }
         revert("KeyManager:_verifyAllowedFunction: not authorised to run this function");

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -278,14 +278,12 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
     function _canSetData(bytes32 _executorPermissions, bytes calldata _data) internal view {
         uint256 keyCount = uint256(bytes32(_data[68:100]));
 
+        uint256 ptrStart = 100;
+
         // loop through the keys
         for (uint256 ii = 0; ii <= keyCount - 1; ii++) {
-            // move calldata pointers
-            uint256 ptrStart = 100 + (32 * ii);
-            uint256 ptrEnd = (100 + (32 * (ii + 1)) - 1);
-
             // extract the key
-            bytes32 setDataKey = bytes32(_data[ptrStart:ptrEnd]);
+            bytes32 setDataKey = bytes32(_data[ptrStart:ptrStart + 32]);
 
             // check if we try to change permissions
             if (bytes8(setDataKey) == _SET_PERMISSIONS) {
@@ -306,6 +304,9 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
                     "KeyManager:_checkPermissions: Not authorized to setData"
                 );
             }
+
+            // move calldata pointers if not at the end of the list
+            if (ii != keyCount - 1) ptrStart += 32;
         }
     }
 

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -206,13 +206,11 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
 
         // loop through the keys
         for (uint256 ii = 0; ii <= keyCount - 1; ii++) {
-            // extract the key
-            bytes32 setDataKey = bytes32(_data[ptrStart:ptrStart + 32]);
+            bytes32 key = bytes32(_data[ptrStart:ptrStart + 32]);
 
-            // check if we try to change permissions
-            if (bytes8(setDataKey) == _SET_PERMISSIONS) {
-                bool isNewAddress = bytes32(ERC725Y(account).getDataSingle(setDataKey)) ==
-                    bytes32(0);
+            // check if the key is related to setting permissions
+            if (bytes8(key) == _SET_PERMISSIONS) {
+                bool isNewAddress = bytes32(ERC725Y(account).getDataSingle(key)) == bytes32(0);
 
                 isNewAddress
                     ? require(

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -193,12 +193,12 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
                 // check if we try to change permissions
                 if (bytes8(setDataKey) == _SET_PERMISSIONS) {
                     require(
-                        _isAllowed(_PERMISSION_CHANGEPERMISSIONS, userPermissions),
+                        _hasPermission(_PERMISSION_CHANGEPERMISSIONS, userPermissions),
                         "KeyManager:_checkPermissions: Not authorized to change keys"
                     );
                 } else {
                     require(
-                        _isAllowed(_PERMISSION_SETDATA, userPermissions),
+                        _hasPermission(_PERMISSION_SETDATA, userPermissions),
                         "KeyManager:_checkPermissions: Not authorized to setData"
                     );
                 }
@@ -237,7 +237,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
                 }
             }
             /* solhint-enable */
-            bool operationAllowed = _isAllowed(permission, userPermissions);
+            bool operationAllowed = _hasPermission(permission, userPermissions);
 
             if (!operationAllowed && (permission == _PERMISSION_CALL)) {
                 revert("KeyManager:_checkPermissions: not authorized to perform CALL");
@@ -259,7 +259,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
 
             if (value > 0) {
                 require(
-                    _isAllowed(_PERMISSION_TRANSFERVALUE, userPermissions),
+                    _hasPermission(_PERMISSION_TRANSFERVALUE, userPermissions),
                     "KeyManager:_checkPermissions: Not authorized to transfer value"
                 );
             }
@@ -275,7 +275,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
             }
         } else if (erc725Selector == _TRANSFEROWNERSHIP_SELECTOR) {
             require(
-                _isAllowed(_PERMISSION_CHANGEOWNER, userPermissions),
+                _hasPermission(_PERMISSION_CHANGEOWNER, userPermissions),
                 "KeyManager:_checkPermissions: Not authorized to transfer ownership"
             );
         } else {
@@ -346,7 +346,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
         }
     }
 
-    function _isAllowed(bytes32 _permission, bytes32 _addressPermission)
+    function _hasPermission(bytes32 _permission, bytes32 _addressPermission)
         internal
         pure
         returns (bool)

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -293,16 +293,16 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
                 isNewAddress
                     ? require(
                         _hasPermission(_PERMISSION_ADDPERMISSIONS, _executorPermissions),
-                        "Not authorized to set permissions for new addresses"
+                        "KeyManager:_canExecute: not authorized to ADDPERMISSIONS"
                     )
                     : require(
                         _hasPermission(_PERMISSION_CHANGEPERMISSIONS, _executorPermissions),
-                        "KeyManager:_checkPermissions: Not authorized to edit permissions of existing addresses"
+                        "KeyManager:_canExecute: not authorized to CHANGEPERMISSIONS"
                     );
             } else {
                 require(
                     _hasPermission(_PERMISSION_SETDATA, _executorPermissions),
-                    "KeyManager:_checkPermissions: Not authorized to setData"
+                    "KeyManager:_canExecute: not authorized to SETDATA"
                 );
             }
 
@@ -316,38 +316,41 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
         uint256 _value,
         bytes32 _userPermissions // bytes calldata _data
     ) internal pure {
-        require(_operationType != 4, "Operation 4 `DELEGATECALL` not supported.");
+        require(
+            _operationType != 4,
+            "KeyManager:_canExecute: operation 4 `DELEGATECALL` not supported"
+        );
 
         require(
             _operationType < 5, // Check for CALL, DEPLOY or STATICCALL
-            "KeyManager:_checkPermissions: Invalid operation type"
+            "KeyManager:_canExecute: invalid operation type"
         );
 
         if (_operationType == 0) {
             require(
                 _hasPermission(_PERMISSION_CALL, _userPermissions),
-                "KeyManager:_checkPermissions: not authorized to perform CALL"
+                "KeyManager:_canExecute: not authorized to CALL"
             );
         }
 
         if (_operationType == 1 || _operationType == 2) {
             require(
                 _hasPermission(_PERMISSION_DEPLOY, _userPermissions),
-                "KeyManager:_checkPermissions: not authorized to perform DEPLOY"
+                "KeyManager:_canExecute: not authorized to DEPLOY"
             );
         }
 
         if (_operationType == 3) {
             require(
                 _hasPermission(_PERMISSION_STATICCALL, _userPermissions),
-                "KeyManager:_checkPermissions: not authorized to perform STATICCALL"
+                "KeyManager:_canExecute: not authorized to STATICCALL"
             );
         }
 
         if (_value > 0) {
             require(
                 _hasPermission(_PERMISSION_TRANSFERVALUE, _userPermissions),
-                "KeyManager:_checkPermissions: Not authorized to transfer value"
+                "KeyManager:_canExecute: not authorized to TRANSFERVALUE"
             );
         }
     }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -275,7 +275,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
         }
     }
 
-    function _canSetData(bytes32 _executorPermissions, bytes calldata _data) internal pure {
+    function _canSetData(bytes32 _executorPermissions, bytes calldata _data) internal view {
         uint256 keyCount = uint256(bytes32(_data[68:100]));
 
         // loop through the keys
@@ -289,10 +289,17 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
 
             // check if we try to change permissions
             if (bytes8(setDataKey) == _SET_PERMISSIONS) {
-                require(
-                    _hasPermission(_PERMISSION_CHANGEPERMISSIONS, _executorPermissions),
-                    "KeyManager:_checkPermissions: Not authorized to change keys"
-                );
+                bool isNewAddress = ERC725Y(account).getDataSingle(setDataKey).length == 0;
+
+                isNewAddress
+                    ? require(
+                        _hasPermission(_PERMISSION_ADDPERMISSIONS, _executorPermissions),
+                        "Not authorized to set permissions for new addresses"
+                    )
+                    : require(
+                        _hasPermission(_PERMISSION_CHANGEPERMISSIONS, _executorPermissions),
+                        "KeyManager:_checkPermissions: Not authorized to edit permissions of existing addresses"
+                    );
             } else {
                 require(
                     _hasPermission(_PERMISSION_SETDATA, _executorPermissions),

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -14,6 +14,10 @@ import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@erc725/smart-contracts/contracts/utils/ERC725Utils.sol";
 
+// constants
+import "./LSP6Constants.sol";
+import "@erc725/smart-contracts/contracts/constants.sol";
+
 /**
  * @title Contract acting as a controller of an ERC725 Account, using permissions stored in the ERC725Y storage
  * @author Fabian Vogelsteller, Jean Cavallera
@@ -26,35 +30,6 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
 
     ERC725 public account;
     mapping(address => mapping(uint256 => uint256)) internal _nonceStore;
-
-    bytes4 internal constant _INTERFACE_ID_ERC1271 = 0x1626ba7e;
-    bytes4 internal constant _ERC1271FAILVALUE = 0xffffffff;
-
-    bytes4 internal constant _INTERFACE_ID_LSP6 = type(ILSP6KeyManager).interfaceId;
-
-    // prettier-ignore
-    /* solhint-disable */
-    // PERMISSION KEYS
-
-    bytes8 internal constant _SET_PERMISSIONS           = 0x4b80742d00000000; // AddressPermissions:<...>
-    bytes12 internal constant _ADDRESS_PERMISSIONS = 0x4b80742d0000000082ac0000; // AddressPermissions:Permissions:<address> --> bytes32
-    bytes12 internal constant _ADDRESS_ALLOWEDADDRESSES = 0x4b80742d00000000c6dd0000; // AddressPermissions:AllowedAddresses:<address> --> address[]
-    bytes12 internal constant _ADDRESS_ALLOWEDFUNCTIONS = 0x4b80742d000000008efe0000; // AddressPermissions:AllowedFunctions:<address> --> bytes4[]
-    bytes12 internal constant _ADDRESS_ALLOWEDSTANDARDS = 0x4b80742d000000003efa0000; // AddressPermissions:AllowedStandards:<address> --> bytes4[]
-    /* solhint-enable */
-
-    // prettier-ignore
-    // PERMISSIONS VALUES
-    bytes32 internal constant _PERMISSION_CHANGEOWNER       = 0x0000000000000000000000000000000000000000000000000000000000000001; // [240 x 0 bits...] 0000 0000 0000 0001
-    bytes32 internal constant _PERMISSION_CHANGEPERMISSIONS = 0x0000000000000000000000000000000000000000000000000000000000000002; // [      ...      ] .... .... .... 0010
-    bytes32 internal constant _PERMISSION_ADDPERMISSIONS    = 0x0000000000000000000000000000000000000000000000000000000000000004; // [      ...      ] .... .... .... 0100
-    bytes32 internal constant _PERMISSION_SETDATA           = 0x0000000000000000000000000000000000000000000000000000000000000008; // [      ...      ] .... .... .... 1000
-    bytes32 internal constant _PERMISSION_CALL              = 0x0000000000000000000000000000000000000000000000000000000000000010; // [      ...      ] .... .... 0001 ....
-    bytes32 internal constant _PERMISSION_STATICCALL        = 0x0000000000000000000000000000000000000000000000000000000000000020; // [      ...      ] .... .... 0010 ....
-    bytes32 internal constant _PERMISSION_DELEGATECALL      = 0x0000000000000000000000000000000000000000000000000000000000000040; // [      ...      ] .... .... 0100 ....
-    bytes32 internal constant _PERMISSION_DEPLOY            = 0x0000000000000000000000000000000000000000000000000000000000000080; // [      ...      ] .... .... 1000 ....
-    bytes32 internal constant _PERMISSION_TRANSFERVALUE     = 0x0000000000000000000000000000000000000000000000000000000000000100; // [      ...      ] .... 0001 .... ....
-    bytes32 internal constant _PERMISSION_SIGN              = 0x0000000000000000000000000000000000000000000000000000000000000200; // [      ...      ] .... 0010 .... ....
 
     /* solhint-disable */
     // selectors

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
@@ -7,9 +7,8 @@ import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 contract LSP6KeyManagerInit is Initializable, LSP6KeyManagerCore {
-
     function initialize(address _account) public initializer {
         account = ERC725(_account);
-        _registerInterface(_INTERFACE_ID_LSP6);
+        _registerInterface(_LSP6_INTERFACE_ID);
     }
 }

--- a/contracts/Utils/LSP2Utils.sol
+++ b/contracts/Utils/LSP2Utils.sol
@@ -9,24 +9,25 @@ pragma solidity ^0.8.0;
  */
 library LSP2Utils {
     /* solhint-disable no-inline-assembly */
-    function generateSingletonKey(string memory _keyName) public pure returns (bytes32) {
+    function generateSingletonKey(string memory _keyName) internal pure returns (bytes32) {
         return keccak256(bytes(_keyName));
     }
 
-    function generateArrayKey(string memory _keyName) public pure returns (bytes32) {
+    function generateArrayKey(string memory _keyName) internal pure returns (bytes32) {
         bytes memory keyName = bytes(_keyName);
 
+        // prettier-ignore
         require(
             keyName[keyName.length - 2] == 0x5b && // "[" in utf8 encoded
                 keyName[keyName.length - 1] == 0x5d, // "]" in utf8
-            'Missing empty square brackets "[]" at the end of the key name'
+            "Missing empty square brackets \"[]\" at the end of the key name"
         );
 
         return keccak256(keyName);
     }
 
     function generateMappingKey(string memory _firstWord, string memory _lastWord)
-        public
+        internal
         pure
         returns (bytes32 key_)
     {
@@ -45,7 +46,7 @@ library LSP2Utils {
     }
 
     function generateBytes20MappingKey(string memory _firstWord, address _address)
-        public
+        internal
         pure
         returns (bytes32 key_)
     {
@@ -62,7 +63,7 @@ library LSP2Utils {
         string memory _firstWord,
         string memory _secondWord,
         address _address
-    ) public pure returns (bytes32 key_) {
+    ) internal pure returns (bytes32 key_) {
         bytes32 firstWordHash = keccak256(bytes(_firstWord));
         bytes32 secondWordHash = keccak256(bytes(_secondWord));
 
@@ -84,7 +85,7 @@ library LSP2Utils {
         pure
         returns (bytes32)
     {
-        bytes memory generatedKey = abi.encodePacked(_keyPrefix, _bytes20);
+        bytes memory generatedKey = bytes.concat(_keyPrefix, _bytes20);
         bytes32 toBytes32Key;
         // solhint-disable-next-line
         assembly {
@@ -97,7 +98,7 @@ library LSP2Utils {
         string memory _hashFunction,
         string memory _json,
         string memory _url
-    ) public pure returns (bytes memory key_) {
+    ) internal pure returns (bytes memory key_) {
         bytes32 hashFunctionDigest = keccak256(bytes(_hashFunction));
         bytes32 jsonDigest = keccak256(bytes(_json));
 
@@ -108,7 +109,7 @@ library LSP2Utils {
         string memory _hashFunction,
         string memory _assetBytes,
         string memory _url
-    ) public pure returns (bytes memory key_) {
+    ) internal pure returns (bytes memory key_) {
         bytes32 hashFunctionDigest = keccak256(bytes(_hashFunction));
         bytes32 jsonDigest = keccak256(bytes(_assetBytes));
 

--- a/contracts/Utils/LSP2Utils.sol
+++ b/contracts/Utils/LSP2Utils.sol
@@ -9,30 +9,22 @@ pragma solidity ^0.8.0;
  */
 library LSP2Utils {
     /* solhint-disable no-inline-assembly */
-    function generateSingletonKey(string memory _keyName)
-        public 
-        pure
-        returns (bytes32)
-    {
+    function generateSingletonKey(string memory _keyName) public pure returns (bytes32) {
         return keccak256(bytes(_keyName));
-    }   
+    }
 
-    function generateArrayKey(string memory _keyName)
-        public
-        pure
-        returns (bytes32)
-    {
+    function generateArrayKey(string memory _keyName) public pure returns (bytes32) {
         bytes memory keyName = bytes(_keyName);
-        
+
         require(
-            keyName[keyName.length - 2] == 0x5b // "[" in utf8 encoded
-            && keyName[keyName.length - 1] == 0x5d,  // "]" in utf8
-            "Missing empty square brackets \"[]\" at the end of the key name"
+            keyName[keyName.length - 2] == 0x5b && // "[" in utf8 encoded
+                keyName[keyName.length - 1] == 0x5d, // "]" in utf8
+            'Missing empty square brackets "[]" at the end of the key name'
         );
 
         return keccak256(keyName);
     }
-    
+
     function generateMappingKey(string memory _firstWord, string memory _lastWord)
         public
         pure
@@ -40,47 +32,37 @@ library LSP2Utils {
     {
         bytes32 firstWordHash = keccak256(bytes(_firstWord));
         bytes32 lastWordHash = keccak256(bytes(_lastWord));
-        
+
         bytes memory temporaryBytes = abi.encodePacked(
-            bytes16(firstWordHash), 
-            bytes12(0), 
+            bytes16(firstWordHash),
+            bytes12(0),
             bytes4(lastWordHash)
         );
-        
-        assembly {
-            key_ := mload(add(temporaryBytes, 32))
-        }
-    
-    }
-
-    function generateAddressMappingKey(string memory _firstWord, address _address)
-        public 
-        pure
-        returns (bytes32 key_)
-    {   
-        bytes32 firstWordHash = keccak256(bytes(_firstWord));
-
-        bytes memory temporaryBytes = abi.encodePacked(
-            bytes8(firstWordHash), 
-            bytes4(0), 
-            _address
-        );
 
         assembly {
             key_ := mload(add(temporaryBytes, 32))
         }
-
     }
 
-    function generateAddressMappingWithGroupingKey(
-        string memory _firstWord, 
-        string memory _secondWord, 
-        address _address
-    )
+    function generateBytes20MappingKey(string memory _firstWord, address _address)
         public
         pure
         returns (bytes32 key_)
     {
+        bytes32 firstWordHash = keccak256(bytes(_firstWord));
+
+        bytes memory temporaryBytes = abi.encodePacked(bytes8(firstWordHash), bytes4(0), _address);
+
+        assembly {
+            key_ := mload(add(temporaryBytes, 32))
+        }
+    }
+
+    function generateBytes20MappingWithGroupingKey(
+        string memory _firstWord,
+        string memory _secondWord,
+        address _address
+    ) public pure returns (bytes32 key_) {
         bytes32 firstWordHash = keccak256(bytes(_firstWord));
         bytes32 secondWordHash = keccak256(bytes(_secondWord));
 
@@ -97,42 +79,39 @@ library LSP2Utils {
         }
     }
 
-    function generateJSONURLValue(
-        string memory _hashFunction, 
-        string memory _json, 
-        string memory _url
-    ) 
-        public
+    function generateBytes20MappingWithGroupingKey(bytes12 _keyPrefix, bytes20 _bytes20)
+        internal
         pure
-        returns (bytes memory key_)
+        returns (bytes32)
     {
+        bytes memory generatedKey = abi.encodePacked(_keyPrefix, _bytes20);
+        bytes32 toBytes32Key;
+        // solhint-disable-next-line
+        assembly {
+            toBytes32Key := mload(add(generatedKey, 32))
+        }
+        return toBytes32Key;
+    }
+
+    function generateJSONURLValue(
+        string memory _hashFunction,
+        string memory _json,
+        string memory _url
+    ) public pure returns (bytes memory key_) {
         bytes32 hashFunctionDigest = keccak256(bytes(_hashFunction));
         bytes32 jsonDigest = keccak256(bytes(_json));
 
-        key_ = abi.encodePacked(
-            bytes4(hashFunctionDigest),
-            jsonDigest,
-            _url
-        );
+        key_ = abi.encodePacked(bytes4(hashFunctionDigest), jsonDigest, _url);
     }
 
     function generateASSETURLValue(
-        string memory _hashFunction, 
-        string memory _assetBytes, 
+        string memory _hashFunction,
+        string memory _assetBytes,
         string memory _url
-    )
-        public
-        pure
-        returns (bytes memory key_)
-    {
+    ) public pure returns (bytes memory key_) {
         bytes32 hashFunctionDigest = keccak256(bytes(_hashFunction));
         bytes32 jsonDigest = keccak256(bytes(_assetBytes));
 
-        key_ = abi.encodePacked(
-            bytes4(hashFunctionDigest),
-            jsonDigest,
-            _url
-        );
+        key_ = abi.encodePacked(bytes4(hashFunctionDigest), jsonDigest, _url);
     }
-
 }

--- a/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
@@ -405,7 +405,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.connect(app).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: not authorized to perform STATICCALL"
+        "KeyManager:_canExecute: not authorized to STATICCALL"
       );
     });
 
@@ -418,7 +418,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.connect(owner).execute(executePayload)).toBeRevertedWith(
-        "Operation 4 `DELEGATECALL` not supported."
+        "KeyManager:_canExecute: operation 4 `DELEGATECALL` not supported"
       );
     });
 
@@ -431,7 +431,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.connect(app).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: not authorized to perform DEPLOY"
+        "KeyManager:_canExecute: not authorized to DEPLOY"
       );
     });
   });
@@ -474,7 +474,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.connect(app).execute(transferPayload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: Not authorized to transfer value"
+        "KeyManager:_canExecute: not authorized to TRANSFERVALUE"
       );
 
       let newAccountBalance = await provider.getBalance(universalProfile.address);
@@ -717,7 +717,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.execute(payload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: Invalid operation type"
+        "KeyManager:_canExecute: invalid operation type"
       );
     });
 
@@ -1361,7 +1361,7 @@ describe("SETDATA", () => {
         let payload = universalProfile.interface.encodeFunctionData("setData", [[key], [value]]);
 
         await expect(keyManager.connect(cannotSetData).execute(payload)).toBeRevertedWith(
-          "KeyManager:_checkPermissions: Not authorized to setData"
+          "KeyManager:_canExecute: not authorized to SETDATA"
         );
       });
     });
@@ -1544,7 +1544,7 @@ describe("SETDATA", () => {
         let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
 
         await expect(keyManager.connect(cannotSetData).execute(payload)).toBeRevertedWith(
-          "KeyManager:_checkPermissions: Not authorized to setData"
+          "KeyManager:_canExecute: not authorized to SETDATA"
         );
       });
 
@@ -1567,7 +1567,7 @@ describe("SETDATA", () => {
         let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
 
         await expect(keyManager.connect(cannotSetData).execute(payload)).toBeRevertedWith(
-          "KeyManager:_checkPermissions: Not authorized to setData"
+          "KeyManager:_canExecute: not authorized to SETDATA"
         );
       });
 
@@ -1599,7 +1599,7 @@ describe("SETDATA", () => {
         let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
 
         await expect(keyManager.connect(cannotSetData).execute(payload)).toBeRevertedWith(
-          "KeyManager:_checkPermissions: Not authorized to setData"
+          "KeyManager:_canExecute: not authorized to SETDATA"
         );
       });
     });
@@ -1710,9 +1710,7 @@ describe("CHANGE / ADD PERMISSIONS", () => {
 
         await expect(
           keyManager.connect(canOnlyAddPermissions).execute(maliciousPayload)
-        ).toBeRevertedWith(
-          "KeyManager:_checkPermissions: Not authorized to edit permissions of existing addresses"
-        );
+        ).toBeRevertedWith("KeyManager:_canExecute: not authorized to CHANGEPERMISSIONS");
       });
     });
 
@@ -1732,7 +1730,7 @@ describe("CHANGE / ADD PERMISSIONS", () => {
 
         await expect(
           keyManager.connect(canOnlyChangePermissions).execute(maliciousPayload)
-        ).toBeRevertedWith("Not authorized to set permissions for new addresses");
+        ).toBeRevertedWith("KeyManager:_canExecute: not authorized to ADDPERMISSIONS");
       });
 
       it("should be allowed to change permissions", async () => {
@@ -1754,7 +1752,7 @@ describe("CHANGE / ADD PERMISSIONS", () => {
 
         await expect(
           keyManager.connect(canOnlyChangePermissions).execute(payload)
-        ).toBeRevertedWith("Not authorized to set permissions for new addresses");
+        ).toBeRevertedWith("KeyManager:_canExecute: not authorized to ADDPERMISSIONS");
       });
     });
   });
@@ -1928,9 +1926,7 @@ describe("setting mixed keys (SETDATA + CHANGE / ADD PERMISSIONS)", () => {
 
       await expect(
         keyManager.connect(canSetDataAndAddPermissions).execute(payload)
-      ).toBeRevertedWith(
-        "KeyManager:_checkPermissions: Not authorized to edit permissions of existing addresses"
-      );
+      ).toBeRevertedWith("KeyManager:_canExecute: not authorized to CHANGEPERMISSIONS");
     });
 
     it("(should fail): 2 x keys + (add 1 x new permission) + (change 1 x existing permission)", async () => {
@@ -1954,9 +1950,7 @@ describe("setting mixed keys (SETDATA + CHANGE / ADD PERMISSIONS)", () => {
 
       await expect(
         keyManager.connect(canSetDataAndAddPermissions).execute(payload)
-      ).toBeRevertedWith(
-        "KeyManager:_checkPermissions: Not authorized to edit permissions of existing addresses"
-      );
+      ).toBeRevertedWith("KeyManager:_canExecute: not authorized to CHANGEPERMISSIONS");
     });
   });
 
@@ -1983,7 +1977,7 @@ describe("setting mixed keys (SETDATA + CHANGE / ADD PERMISSIONS)", () => {
 
       await expect(
         keyManager.connect(canSetDataAndChangePermissions).execute(payload)
-      ).toBeRevertedWith("Not authorized to set permissions for new addresses");
+      ).toBeRevertedWith("KeyManager:_canExecute: not authorized to ADDPERMISSIONS");
     });
 
     it("(should pass): 2 x keys + change 2 x existing permissions", async () => {
@@ -2029,7 +2023,7 @@ describe("setting mixed keys (SETDATA + CHANGE / ADD PERMISSIONS)", () => {
 
       await expect(
         keyManager.connect(canSetDataAndChangePermissions).execute(payload)
-      ).toBeRevertedWith("Not authorized to set permissions for new addresses");
+      ).toBeRevertedWith("KeyManager:_canExecute: not authorized to ADDPERMISSIONS");
     });
   });
 });

--- a/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
@@ -405,7 +405,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.connect(app).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_canExecute: not authorized to STATICCALL"
+        "KeyManager:_verifyCanExecute: not authorized to STATICCALL"
       );
     });
 
@@ -418,7 +418,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.connect(owner).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_canExecute: operation 4 `DELEGATECALL` not supported"
+        "KeyManager:_verifyCanExecute: operation 4 `DELEGATECALL` not supported"
       );
     });
 
@@ -431,7 +431,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.connect(app).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_canExecute: not authorized to DEPLOY"
+        "KeyManager:_verifyCanExecute: not authorized to DEPLOY"
       );
     });
   });
@@ -474,7 +474,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.connect(app).execute(transferPayload)).toBeRevertedWith(
-        "KeyManager:_canExecute: not authorized to TRANSFERVALUE"
+        "KeyManager:_verifyCanExecute: not authorized to TRANSFERVALUE"
       );
 
       let newAccountBalance = await provider.getBalance(universalProfile.address);
@@ -543,7 +543,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.connect(app).execute(payload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: Not authorized to interact with this address"
+        "KeyManager:_verifyIfAllowedAddress: Not authorized to interact with this address"
       );
     });
   });
@@ -558,7 +558,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.connect(app).execute(payload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: Not authorised to run this function"
+        "KeyManager:_verifyIfAllowedFunction: not authorised to run this function"
       );
     });
   });
@@ -662,7 +662,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.connect(app).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: Not authorised to run this function"
+        "KeyManager:_verifyIfAllowedFunction: not authorised to run this function"
       );
 
       let result = await targetContract.callStatic.getNumber();
@@ -717,13 +717,13 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.execute(payload)).toBeRevertedWith(
-        "KeyManager:_canExecute: invalid operation type"
+        "KeyManager:_verifyCanExecute: invalid operation type"
       );
     });
 
     it("Should revert because calling an unexisting function in ERC725", async () => {
       await expect(keyManager.execute("0xbad000000000000000000000000bad")).toBeRevertedWith(
-        "KeyManager:_checkPermissions: unknown function selector on ERC725 account"
+        "KeyManager:_verifyPermissions: unknown function selector on ERC725 account"
       );
     });
 
@@ -856,7 +856,9 @@ describe("KeyManager", () => {
 
       await expect(
         keyManager.executeRelayCall(keyManager.address, nonce, executeRelayCallPayload, signature)
-      ).toBeRevertedWith("KeyManager:_checkPermissions: Not authorised to run this function");
+      ).toBeRevertedWith(
+        "KeyManager:_verifyIfAllowedFunction: not authorised to run this function"
+      );
 
       let endResult = await targetContract.callStatic.getNumber();
       expect(endResult.toString()).toEqual(currentNumber.toString());
@@ -1196,7 +1198,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.connect(accounts[6]).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_getUserPermissions: no permissions set for this user / caller"
+        "KeyManager:_getAddressPermissions: no permissions set for this address"
       );
     });
 
@@ -1361,7 +1363,7 @@ describe("SETDATA", () => {
         let payload = universalProfile.interface.encodeFunctionData("setData", [[key], [value]]);
 
         await expect(keyManager.connect(cannotSetData).execute(payload)).toBeRevertedWith(
-          "KeyManager:_canExecute: not authorized to SETDATA"
+          "KeyManager:_verifyCanSetData: not authorized to SETDATA"
         );
       });
     });
@@ -1544,7 +1546,7 @@ describe("SETDATA", () => {
         let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
 
         await expect(keyManager.connect(cannotSetData).execute(payload)).toBeRevertedWith(
-          "KeyManager:_canExecute: not authorized to SETDATA"
+          "KeyManager:_verifyCanSetData: not authorized to SETDATA"
         );
       });
 
@@ -1567,7 +1569,7 @@ describe("SETDATA", () => {
         let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
 
         await expect(keyManager.connect(cannotSetData).execute(payload)).toBeRevertedWith(
-          "KeyManager:_canExecute: not authorized to SETDATA"
+          "KeyManager:_verifyCanSetData: not authorized to SETDATA"
         );
       });
 
@@ -1599,7 +1601,7 @@ describe("SETDATA", () => {
         let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
 
         await expect(keyManager.connect(cannotSetData).execute(payload)).toBeRevertedWith(
-          "KeyManager:_canExecute: not authorized to SETDATA"
+          "KeyManager:_verifyCanSetData: not authorized to SETDATA"
         );
       });
     });
@@ -1710,7 +1712,7 @@ describe("CHANGE / ADD PERMISSIONS", () => {
 
         await expect(
           keyManager.connect(canOnlyAddPermissions).execute(maliciousPayload)
-        ).toBeRevertedWith("KeyManager:_canExecute: not authorized to CHANGEPERMISSIONS");
+        ).toBeRevertedWith("KeyManager:_verifyCanSetData: not authorized to CHANGEPERMISSIONS");
       });
     });
 
@@ -1730,7 +1732,7 @@ describe("CHANGE / ADD PERMISSIONS", () => {
 
         await expect(
           keyManager.connect(canOnlyChangePermissions).execute(maliciousPayload)
-        ).toBeRevertedWith("KeyManager:_canExecute: not authorized to ADDPERMISSIONS");
+        ).toBeRevertedWith("KeyManager:_verifyCanSetData: not authorized to ADDPERMISSIONS");
       });
 
       it("should be allowed to change permissions", async () => {
@@ -1752,7 +1754,7 @@ describe("CHANGE / ADD PERMISSIONS", () => {
 
         await expect(
           keyManager.connect(canOnlyChangePermissions).execute(payload)
-        ).toBeRevertedWith("KeyManager:_canExecute: not authorized to ADDPERMISSIONS");
+        ).toBeRevertedWith("KeyManager:_verifyCanSetData: not authorized to ADDPERMISSIONS");
       });
     });
   });
@@ -1926,7 +1928,7 @@ describe("setting mixed keys (SETDATA + CHANGE / ADD PERMISSIONS)", () => {
 
       await expect(
         keyManager.connect(canSetDataAndAddPermissions).execute(payload)
-      ).toBeRevertedWith("KeyManager:_canExecute: not authorized to CHANGEPERMISSIONS");
+      ).toBeRevertedWith("KeyManager:_verifyCanSetData: not authorized to CHANGEPERMISSIONS");
     });
 
     it("(should fail): 2 x keys + (add 1 x new permission) + (change 1 x existing permission)", async () => {
@@ -1950,7 +1952,7 @@ describe("setting mixed keys (SETDATA + CHANGE / ADD PERMISSIONS)", () => {
 
       await expect(
         keyManager.connect(canSetDataAndAddPermissions).execute(payload)
-      ).toBeRevertedWith("KeyManager:_canExecute: not authorized to CHANGEPERMISSIONS");
+      ).toBeRevertedWith("KeyManager:_verifyCanSetData: not authorized to CHANGEPERMISSIONS");
     });
   });
 
@@ -1977,7 +1979,7 @@ describe("setting mixed keys (SETDATA + CHANGE / ADD PERMISSIONS)", () => {
 
       await expect(
         keyManager.connect(canSetDataAndChangePermissions).execute(payload)
-      ).toBeRevertedWith("KeyManager:_canExecute: not authorized to ADDPERMISSIONS");
+      ).toBeRevertedWith("KeyManager:_verifyCanSetData: not authorized to ADDPERMISSIONS");
     });
 
     it("(should pass): 2 x keys + change 2 x existing permissions", async () => {
@@ -2023,7 +2025,7 @@ describe("setting mixed keys (SETDATA + CHANGE / ADD PERMISSIONS)", () => {
 
       await expect(
         keyManager.connect(canSetDataAndChangePermissions).execute(payload)
-      ).toBeRevertedWith("KeyManager:_canExecute: not authorized to ADDPERMISSIONS");
+      ).toBeRevertedWith("KeyManager:_verifyCanSetData: not authorized to ADDPERMISSIONS");
     });
   });
 });

--- a/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
@@ -371,13 +371,10 @@ describe("KeyManager", () => {
     }
   });
 
-  describe("> testing permissions: SETDATA", () => {
+  describe("SETDATA", () => {
     let owner: SignerWithAddress, canSetData: SignerWithAddress, cannotSetData: SignerWithAddress;
 
     let universalProfile: UniversalProfile, keyManager: LSP6KeyManager;
-
-    let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key"));
-    let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Hello Lukso!"));
 
     beforeEach(async () => {
       owner = accounts[0];
@@ -408,6 +405,9 @@ describe("KeyManager", () => {
     describe("when setting one key", () => {
       describe("For UP owner", () => {
         it("should pass", async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key"));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Hello Lukso!"));
+
           let payload = universalProfile.interface.encodeFunctionData("setData", [[key], [value]]);
 
           await keyManager.connect(owner).execute(payload);
@@ -418,6 +418,9 @@ describe("KeyManager", () => {
 
       describe("For address that has permission SETDATA", () => {
         it("should pass", async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key"));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Hello Lukso!"));
+
           let payload = universalProfile.interface.encodeFunctionData("setData", [[key], [value]]);
 
           await keyManager.connect(canSetData).execute(payload);
@@ -428,6 +431,9 @@ describe("KeyManager", () => {
 
       describe("For address that doesn't have permission SETDATA", () => {
         it("should not allow", async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key"));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Hello Lukso!"));
+
           let payload = universalProfile.interface.encodeFunctionData("setData", [[key], [value]]);
 
           await expect(keyManager.connect(cannotSetData).execute(payload)).toBeRevertedWith(
@@ -442,12 +448,12 @@ describe("KeyManager", () => {
         it("(should pass): adding 5 singleton keys", async () => {
           // prettier-ignore
           let elements = {
-                              "MyFirstKey": "aaaaaaaaaa",
-                              "MySecondKey": "bbbbbbbbbb",
-                              "MyThirdKey": "cccccccccc",
-                              "MyFourthKey": "dddddddddd",
-                              "MyFifthKey": "eeeeeeeeee",
-                            };
+                "MyFirstKey": "aaaaaaaaaa",
+                "MySecondKey": "bbbbbbbbbb",
+                "MyThirdKey": "cccccccccc",
+                "MyFourthKey": "dddddddddd",
+                "MyFifthKey": "eeeeeeeeee",
+            };
 
           let [keys, values] = generateKeysAndValues(elements);
 
@@ -676,20 +682,20 @@ describe("KeyManager", () => {
     });
   });
 
-  describe("> testing permissions: CHANGE / ADD PERMISSIONS", () => {
+  describe("CHANGE / ADD PERMISSIONS", () => {
     let owner: SignerWithAddress,
-      bob: SignerWithAddress,
       canOnlyAddPermissions: SignerWithAddress,
       canOnlyChangePermissions: SignerWithAddress,
+      bob: SignerWithAddress,
       zeroBytes: SignerWithAddress;
 
     let universalProfile: UniversalProfile, keyManager: LSP6KeyManager;
 
     beforeAll(async () => {
       owner = accounts[0];
-      bob = accounts[1];
-      canOnlyAddPermissions = accounts[2];
-      canOnlyChangePermissions = accounts[3];
+      canOnlyAddPermissions = accounts[1];
+      canOnlyChangePermissions = accounts[2];
+      bob = accounts[3];
       zeroBytes = accounts[4];
 
       universalProfile = await new UniversalProfile__factory(owner).deploy(owner.address);
@@ -698,18 +704,18 @@ describe("KeyManager", () => {
       await universalProfile.connect(owner).setData(
         [
           ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + owner.address.substr(2),
-          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + bob.address.substr(2),
           ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
             canOnlyAddPermissions.address.substr(2),
           ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
             canOnlyChangePermissions.address.substr(2),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + bob.address.substr(2),
           ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + zeroBytes.address.substr(2),
         ],
         [
           ALL_PERMISSIONS_SET,
-          ethers.utils.hexZeroPad(PERMISSIONS.TRANSFERVALUE, 32), // example to test changing bob's permissions
           ethers.utils.hexZeroPad(PERMISSIONS.ADDPERMISSIONS, 32),
           ethers.utils.hexZeroPad(PERMISSIONS.CHANGEPERMISSIONS, 32),
+          ethers.utils.hexZeroPad(PERMISSIONS.TRANSFERVALUE, 32), // example to test changing bob's permissions
           "0x0000000000000000000000000000000000000000000000000000000000000000",
         ]
       );
@@ -717,8 +723,8 @@ describe("KeyManager", () => {
       await universalProfile.connect(owner).transferOwnership(keyManager.address);
     });
 
-    describe("For one permission key", () => {
-      describe("For UP owner", () => {
+    describe("When setting one permission key", () => {
+      describe("From UP owner", () => {
         it("should be allowed to add permissions", async () => {
           let newControllerKey = new ethers.Wallet.createRandom();
 
@@ -749,7 +755,7 @@ describe("KeyManager", () => {
         });
       });
 
-      describe("For address that has permission ADDPERMISSIONS", () => {
+      describe("From an address that has permission ADDPERMISSIONS", () => {
         it("should be allowed to add permissions", async () => {
           let newAddress = new ethers.Wallet.createRandom();
 
@@ -781,7 +787,7 @@ describe("KeyManager", () => {
         });
       });
 
-      describe("For address that has permission CHANGEPERMISSIONS", () => {
+      describe("From an address that has permission CHANGEPERMISSIONS", () => {
         it("should not be allowed to add permissions", async () => {
           // trying to grant full access of the UP to a newly created controller key
           // (so to then gain full control via `maliciousControllerKey`)
@@ -824,9 +830,9 @@ describe("KeyManager", () => {
       });
     });
 
-    describe("For multiple permission keys", () => {
-      describe("For UP owner", () => {
-        it("(should fail): set permissions to 3 addresses", async () => {
+    describe("When setting multiple permission keys", () => {
+      describe("From UP owner", () => {
+        it("(should pass): set permissions to 3 addresses", async () => {
           let keys = [
             ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + user.address.substr(2),
             ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + newUser.address.substr(2),
@@ -842,63 +848,291 @@ describe("KeyManager", () => {
           let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
 
           await keyManager.connect(owner).execute(payload);
+
+          let fetchedResult = await universalProfile.callStatic.getData(keys);
+          expect(fetchedResult).toEqual(values);
         });
       });
     });
   });
 
-  describe.skip("> testing permissions: setting multiple mixed keys (SETDATA + CHANGE / ADD PERMISSIONS)", () => {
-    it("(should fail): set 3 keys + 1 permission", async () => {
-      // prettier-ignore
-      let permissionKeyDisallowed = ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + user.address.substr(2)
-      let permissionValueDisallowed = ethers.utils.hexZeroPad(
-        PERMISSIONS.CALL + PERMISSIONS.TRANSFERVALUE,
-        32
+  describe("setting multiple mixed keys (SETDATA + CHANGE / ADD PERMISSIONS)", () => {
+    let owner: SignerWithAddress,
+      canSetDataAndAddPermissions: SignerWithAddress,
+      canSetDataAndChangePermissions: SignerWithAddress,
+      canSetDataOnly: SignerWithAddress;
+
+    // address to change permissions to
+    let alice: SignerWithAddress, bob: SignerWithAddress;
+
+    let universalProfile: UniversalProfile, keyManager: LSP6KeyManager;
+
+    beforeEach(async () => {
+      owner = accounts[0];
+      canSetDataAndAddPermissions = accounts[1];
+      canSetDataAndChangePermissions = accounts[2];
+      canSetDataOnly = accounts[3];
+
+      alice = accounts[4];
+      bob = accounts[5];
+
+      universalProfile = await new UniversalProfile__factory(owner).deploy(owner.address);
+      keyManager = await new LSP6KeyManager__factory(owner).deploy(universalProfile.address);
+
+      await universalProfile.connect(owner).setData(
+        [
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + owner.address.substr(2),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
+            canSetDataAndAddPermissions.address.substr(2),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
+            canSetDataAndChangePermissions.address.substr(2),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + canSetDataOnly.address.substr(2),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + alice.address.substr(2),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + bob.address.substr(2),
+        ],
+        [
+          ALL_PERMISSIONS_SET,
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA + PERMISSIONS.ADDPERMISSIONS, 32),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA + PERMISSIONS.CHANGEPERMISSIONS, 32),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32),
+          ethers.utils.hexZeroPad(PERMISSIONS.TRANSFERVALUE, 32), // example to test changing Alice permissions
+          ethers.utils.hexZeroPad(PERMISSIONS.TRANSFERVALUE, 32), // example to test changing Bob permissions
+        ]
       );
 
-      let elements = {
-        KeyOne: "1111111111",
-        KeyTwo: "2222222222",
-        KeyThree: "3333333333",
-      };
-      let [keys, values] = generateKeysAndValues(elements);
-
-      keys.push(permissionKeyDisallowed);
-      values.push(permissionValueDisallowed);
-
-      let failingPayload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
-
-      await expect(keyManager.connect(app).execute(failingPayload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: Not authorized to edit permissions of existing addresses"
-      );
+      await universalProfile.connect(owner).transferOwnership(keyManager.address);
     });
 
-    it("(should fail): set 3 keys + 3 permissions", async () => {
-      let elements = {
-        KeyOne: "1111111111",
-        KeyTwo: "2222222222",
-        KeyThree: "3333333333",
-      };
+    describe("From UP owner", () => {
+      it("(should pass): 2 x keys + add 2 x new permissions", async () => {
+        let newControllerKeyOne = new ethers.Wallet.createRandom();
+        let newControllerKeyTwo = new ethers.Wallet.createRandom();
 
-      let [keys, values] = generateKeysAndValues(elements);
+        let keys = [
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My SecondKey Key")),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
+            newControllerKeyOne.address.substr(2),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
+            newControllerKeyTwo.address.substr(2),
+        ];
 
-      keys = keys.concat([
-        ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + user.address.substr(2),
-        ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + newUser.address.substr(2),
-        ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + accounts[6].address.substr(2),
-      ]);
+        let values = [
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32),
+        ];
 
-      values = values.concat([
-        ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32),
-        ethers.utils.hexZeroPad(PERMISSIONS.CALL + PERMISSIONS.TRANSFERVALUE, 32),
-        ethers.utils.hexZeroPad(PERMISSIONS.SIGN, 32),
-      ]);
+        let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
 
-      let failingPayload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
+        await keyManager.connect(owner).execute(payload);
+        let fetchedResult = await universalProfile.getData(keys);
+        expect(fetchedResult).toEqual(values);
+      });
 
-      await expect(keyManager.connect(app).execute(failingPayload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: Not authorized to edit permissions of existing addresses"
-      );
+      it("(should pass): 2 x keys + change 2 x existing permissions", async () => {
+        let keys = [
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My SecondKey Key")),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + alice.address.substr(2),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + bob.address.substr(2),
+        ];
+
+        let values = [
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA + PERMISSIONS.TRANSFERVALUE, 32),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA + PERMISSIONS.TRANSFERVALUE, 32),
+        ];
+
+        let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
+
+        await keyManager.connect(owner).execute(payload);
+        let fetchedResult = await universalProfile.getData(keys);
+        expect(fetchedResult).toEqual(values);
+      });
+
+      it("(should pass): 2 x keys + (add 1 x new permission) + (change 1 x existing permission)", async () => {
+        let newControllerKeyOne = new ethers.Wallet.createRandom();
+
+        let keys = [
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My SecondKey Key")),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
+            newControllerKeyOne.address.substr(2),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + alice.address.substr(2),
+        ];
+
+        let values = [
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+          ethers.utils.hexZeroPad(PERMISSIONS.SIGN, 32),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA + PERMISSIONS.TRANSFERVALUE, 32),
+        ];
+
+        let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
+
+        await keyManager.connect(owner).execute(payload);
+        let fetchedResult = await universalProfile.getData(keys);
+        expect(fetchedResult).toEqual(values);
+      });
+    });
+
+    describe("From address that has permission ADDPERMISSIONS", () => {
+      it("(should pass): 2 x keys + add 2 x new permissions", async () => {
+        let newControllerKeyOne = new ethers.Wallet.createRandom();
+        let newControllerKeyTwo = new ethers.Wallet.createRandom();
+
+        let keys = [
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My SecondKey Key")),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
+            newControllerKeyOne.address.substr(2),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
+            newControllerKeyTwo.address.substr(2),
+        ];
+
+        let values = [
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32),
+        ];
+
+        let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
+
+        await keyManager.connect(canSetDataAndAddPermissions).execute(payload);
+        let fetchedResult = await universalProfile.getData(keys);
+        expect(fetchedResult).toEqual(values);
+      });
+
+      it("(should fail): 2 x keys + change 2 x existing permissions", async () => {
+        let keys = [
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My SecondKey Key")),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + alice.address.substr(2),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + bob.address.substr(2),
+        ];
+
+        let values = [
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA + PERMISSIONS.TRANSFERVALUE, 32),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA + PERMISSIONS.TRANSFERVALUE, 32),
+        ];
+
+        let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
+
+        await expect(
+          keyManager.connect(canSetDataAndAddPermissions).execute(payload)
+        ).toBeRevertedWith(
+          "KeyManager:_checkPermissions: Not authorized to edit permissions of existing addresses"
+        );
+      });
+
+      it("(should fail): 2 x keys + (add 1 x new permission) + (change 1 x existing permission)", async () => {
+        let newControllerKeyOne = new ethers.Wallet.createRandom();
+
+        let keys = [
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My SecondKey Key")),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
+            newControllerKeyOne.address.substr(2),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + alice.address.substr(2),
+        ];
+
+        let values = [
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+          ethers.utils.hexZeroPad(PERMISSIONS.SIGN, 32),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA + PERMISSIONS.TRANSFERVALUE, 32),
+        ];
+
+        let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
+
+        await expect(
+          keyManager.connect(canSetDataAndAddPermissions).execute(payload)
+        ).toBeRevertedWith(
+          "KeyManager:_checkPermissions: Not authorized to edit permissions of existing addresses"
+        );
+      });
+    });
+
+    describe("From address that has permission CHANGEPERMISSIONS", () => {
+      it("(should fail): 2 x keys + add 2 x new permissions", async () => {
+        let newControllerKeyOne = new ethers.Wallet.createRandom();
+        let newControllerKeyTwo = new ethers.Wallet.createRandom();
+
+        let keys = [
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My SecondKey Key")),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
+            newControllerKeyOne.address.substr(2),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
+            newControllerKeyTwo.address.substr(2),
+        ];
+
+        let values = [
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32),
+        ];
+
+        let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
+
+        await expect(
+          keyManager.connect(canSetDataAndChangePermissions).execute(payload)
+        ).toBeRevertedWith("Not authorized to set permissions for new addresses");
+      });
+
+      it("(should pass): 2 x keys + change 2 x existing permissions", async () => {
+        let keys = [
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My SecondKey Key")),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + alice.address.substr(2),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + bob.address.substr(2),
+        ];
+
+        let values = [
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA + PERMISSIONS.TRANSFERVALUE, 32),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA + PERMISSIONS.TRANSFERVALUE, 32),
+        ];
+
+        let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
+
+        await keyManager.connect(canSetDataAndChangePermissions).execute(payload);
+        let fetchedResult = await universalProfile.getData(keys);
+        expect(fetchedResult).toEqual(values);
+      });
+
+      it("(should fail): 2 x keys + (add 1 x new permission) + (change 1 x existing permission)", async () => {
+        let newControllerKeyOne = new ethers.Wallet.createRandom();
+
+        let keys = [
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My SecondKey Key")),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
+            newControllerKeyOne.address.substr(2),
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + alice.address.substr(2),
+        ];
+
+        let values = [
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+          ethers.utils.hexZeroPad(PERMISSIONS.SIGN, 32),
+          ethers.utils.hexZeroPad(PERMISSIONS.SETDATA + PERMISSIONS.TRANSFERVALUE, 32),
+        ];
+
+        let payload = universalProfile.interface.encodeFunctionData("setData", [keys, values]);
+
+        await expect(
+          keyManager.connect(canSetDataAndChangePermissions).execute(payload)
+        ).toBeRevertedWith("Not authorized to set permissions for new addresses");
+      });
     });
   });
 

--- a/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
@@ -164,22 +164,22 @@ describe("Testing KeyManager's internal functions (KeyManagerHelper)", () => {
   });
 
   describe("Testing allowed addresses / function", () => {
-    it("_verifyIfAllowedAddress(...) - Should not revert for address listed in owner's allowed addresses list", async () => {
+    it("_verifyAllowedAddress(...) - Should not revert for address listed in owner's allowed addresses list", async () => {
       await keyManagerHelper.verifyIfAllowedAddress(owner.address, allowedAddresses[0]);
     });
 
-    it("_verifyIfAllowedAddress(...) - Should revert for address not listed in owner's allowed addresses list", async () => {
+    it("_verifyAllowedAddress(...) - Should revert for address not listed in owner's allowed addresses list", async () => {
       await expect(
         keyManagerHelper.verifyIfAllowedAddress(
           owner.address,
           "0xdeadbeefdeadbeefdeaddeadbeefdeadbeefdead"
         )
       ).toBeRevertedWith(
-        "KeyManager:_verifyIfAllowedAddress: Not authorized to interact with this address"
+        "KeyManager:_verifyAllowedAddress: Not authorized to interact with this address"
       );
     });
 
-    it("_verifyIfAllowedAddress(...) - Should not revert when user has no address listed (= all addresses whitelisted)", async () => {
+    it("_verifyAllowedAddress(...) - Should not revert when user has no address listed (= all addresses whitelisted)", async () => {
       await keyManagerHelper.verifyIfAllowedAddress(user.address, app.address);
     });
   });
@@ -536,7 +536,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.connect(app).execute(payload)).toBeRevertedWith(
-        "KeyManager:_verifyIfAllowedAddress: Not authorized to interact with this address"
+        "KeyManager:_verifyAllowedAddress: Not authorized to interact with this address"
       );
     });
   });
@@ -551,7 +551,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.connect(app).execute(payload)).toBeRevertedWith(
-        "KeyManager:_verifyIfAllowedFunction: not authorised to run this function"
+        "KeyManager:_verifyAllowedFunction: not authorised to run this function"
       );
     });
   });
@@ -655,7 +655,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.connect(app).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_verifyIfAllowedFunction: not authorised to run this function"
+        "KeyManager:_verifyAllowedFunction: not authorised to run this function"
       );
 
       let result = await targetContract.callStatic.getNumber();
@@ -849,9 +849,7 @@ describe("KeyManager", () => {
 
       await expect(
         keyManager.executeRelayCall(keyManager.address, nonce, executeRelayCallPayload, signature)
-      ).toBeRevertedWith(
-        "KeyManager:_verifyIfAllowedFunction: not authorised to run this function"
-      );
+      ).toBeRevertedWith("KeyManager:_verifyAllowedFunction: not authorised to run this function");
 
       let endResult = await targetContract.callStatic.getNumber();
       expect(endResult.toString()).toEqual(currentNumber.toString());

--- a/tests/LSP6KeyManager/LSP6KeyManagerProxy.spec.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManagerProxy.spec.ts
@@ -291,7 +291,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(app).execute(dangerousPayload)).toBeRevertedWith(
-        "KeyManager:_canExecute: not authorized to CHANGEPERMISSIONS"
+        "KeyManager:_verifyCanSetData: not authorized to CHANGEPERMISSIONS"
       );
     });
 
@@ -369,7 +369,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(app).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_canExecute: not authorized to STATICCALL"
+        "KeyManager:_verifyCanExecute: not authorized to STATICCALL"
       );
     });
 
@@ -382,7 +382,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(owner).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_canExecute: operation 4 `DELEGATECALL` not supported"
+        "KeyManager:_verifyCanExecute: operation 4 `DELEGATECALL` not supported"
       );
     });
 
@@ -395,7 +395,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(app).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_canExecute: not authorized to DEPLOY"
+        "KeyManager:_verifyCanExecute: not authorized to DEPLOY"
       );
     });
   });
@@ -438,7 +438,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(app).execute(transferPayload)).toBeRevertedWith(
-        "KeyManager:_canExecute: not authorized to TRANSFERVALUE"
+        "KeyManager:_verifyCanExecute: not authorized to TRANSFERVALUE"
       );
 
       let newAccountBalance = await provider.getBalance(proxyUniversalProfile.address);
@@ -507,7 +507,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(app).execute(payload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: Not authorized to interact with this address"
+        "KeyManager:_verifyIfAllowedAddress: Not authorized to interact with this address"
       );
     });
   });
@@ -522,7 +522,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(app).execute(payload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: Not authorised to run this function"
+        "KeyManager:_verifyIfAllowedFunction: not authorised to run this function"
       );
     });
   });
@@ -626,7 +626,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(app).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: Not authorised to run this function"
+        "KeyManager:_verifyIfAllowedFunction: not authorised to run this function"
       );
 
       let result = await targetContract.callStatic.getNumber();
@@ -681,13 +681,13 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.execute(payload)).toBeRevertedWith(
-        "KeyManager:_canExecute: invalid operation type"
+        "KeyManager:_verifyCanExecute: invalid operation type"
       );
     });
 
     it("Should revert because calling an unexisting function in ERC725", async () => {
       await expect(proxyKeyManager.execute("0xbad000000000000000000000000bad")).toBeRevertedWith(
-        "KeyManager:_checkPermissions: unknown function selector on ERC725 account"
+        "KeyManager:_verifyPermissions: unknown function selector on ERC725 account"
       );
     });
 
@@ -825,7 +825,9 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
           executeRelayCallPayload,
           signature
         )
-      ).toBeRevertedWith("KeyManager:_checkPermissions: Not authorised to run this function");
+      ).toBeRevertedWith(
+        "KeyManager:_verifyIfAllowedFunction: not authorised to run this function"
+      );
 
       let endResult = await targetContract.callStatic.getNumber();
       expect(endResult.toString()).toEqual(currentNumber.toString());
@@ -1149,7 +1151,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(accounts[6]).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_getUserPermissions: no permissions set for this user / caller"
+        "KeyManager:_getAddressPermissions: no permissions set for this address"
       );
     });
 

--- a/tests/LSP6KeyManager/LSP6KeyManagerProxy.spec.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManagerProxy.spec.ts
@@ -291,7 +291,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(app).execute(dangerousPayload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: Not authorized to change keys"
+        "KeyManager:_canExecute: not authorized to CHANGEPERMISSIONS"
       );
     });
 
@@ -369,7 +369,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(app).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: not authorized to perform STATICCALL"
+        "KeyManager:_canExecute: not authorized to STATICCALL"
       );
     });
 
@@ -382,7 +382,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(owner).execute(executePayload)).toBeRevertedWith(
-        "Operation 4 `DELEGATECALL` not supported."
+        "KeyManager:_canExecute: operation 4 `DELEGATECALL` not supported"
       );
     });
 
@@ -395,7 +395,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(app).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: not authorized to perform DEPLOY"
+        "KeyManager:_canExecute: not authorized to DEPLOY"
       );
     });
   });
@@ -438,7 +438,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(app).execute(transferPayload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: Not authorized to transfer value"
+        "KeyManager:_canExecute: not authorized to TRANSFERVALUE"
       );
 
       let newAccountBalance = await provider.getBalance(proxyUniversalProfile.address);
@@ -681,7 +681,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.execute(payload)).toBeRevertedWith(
-        "KeyManager:_checkPermissions: Invalid operation type"
+        "KeyManager:_canExecute: invalid operation type"
       );
     });
 

--- a/tests/LSP6KeyManager/LSP6KeyManagerProxy.spec.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManagerProxy.spec.ts
@@ -507,7 +507,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(app).execute(payload)).toBeRevertedWith(
-        "KeyManager:_verifyIfAllowedAddress: Not authorized to interact with this address"
+        "KeyManager:_verifyAllowedAddress: Not authorized to interact with this address"
       );
     });
   });
@@ -522,7 +522,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(app).execute(payload)).toBeRevertedWith(
-        "KeyManager:_verifyIfAllowedFunction: not authorised to run this function"
+        "KeyManager:_verifyAllowedFunction: not authorised to run this function"
       );
     });
   });
@@ -626,7 +626,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       ]);
 
       await expect(proxyKeyManager.connect(app).execute(executePayload)).toBeRevertedWith(
-        "KeyManager:_verifyIfAllowedFunction: not authorised to run this function"
+        "KeyManager:_verifyAllowedFunction: not authorised to run this function"
       );
 
       let result = await targetContract.callStatic.getNumber();
@@ -825,9 +825,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
           executeRelayCallPayload,
           signature
         )
-      ).toBeRevertedWith(
-        "KeyManager:_verifyIfAllowedFunction: not authorised to run this function"
-      );
+      ).toBeRevertedWith("KeyManager:_verifyAllowedFunction: not authorised to run this function");
 
       let endResult = await targetContract.callStatic.getNumber();
       expect(endResult.toString()).toEqual(currentNumber.toString());


### PR DESCRIPTION
# What does this PR introduce?

**new `ADDPERMISSIONS`**
- added check for `ADD` _vs_ `CHANGE` permissions when setting new permissions via `setData` + tests 🧪 

**Refactoring** 
- use `LSP2Utils` to create keys for reading `AddressPermissions:Permissions:<address>`, etc... on ERC725Y key-value store. This is done via the function `generateBytes20MappingWithGroupingKey`  🧰 
- moved all permission keys + values inside `LSP6Constants.sol`
- break-down internal logic of function `_verifypermissions` into smaller internal functions calls: 
    - `_verifyCanSetdata`, 
    - `_verifyCanExecute`, 
    - `_verifyIfAllowedAddress`
    - `_verifyIfAllowedFunctions`


**Functions + Variables renamed**
-  ~`_checkPermissions`~ -> now `_verifyPermissions`
- ~`_verifyNonce`~ -> now `_isValidNonce`
- ~`_getUserPermissions`~ -> now `_getAddressPermissions`

Also aimed to give more standard variable names inside the Solidity code like:
- `toAddress` instead of ~`recipient`~ when verifying an `account.execute` request
- in `executeRelayCall`: `signer` instead of `from`

**Layout**
- organised functions in order ( 1) `public`,  2) `internal`)


**Tests**

- added tests for `ADDPERMISSIONS` _vs `CHANGEPERMISSIONS` (including group of generic LSP2 keys / LSP6 permission keys)


**NB: ** there are still the tests missing for the proxy version of the Key Manager. But the test files has to be broken down into `LSP6KeyManager.spec.ts` and `LSP6KeyManager.behaviour.ts`, to avoid duplicate code for tests.


