### PR TITLE
chore: remove `.gitmodules` file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "contracts/_ERCs/ERC725"]
-	path = submodules/ERC725
-	url = https://github.com/ERC725Alliance/ERC725.git


### PR DESCRIPTION
Deleted file at root related to submodules that we do not use anymore.