### PR TITLE
release: 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.4.1](https://github.com/lukso-network/universalprofile-smart-contracts/compare/v0.4.0...v0.4.1) (2021-11-26)
+
 ## [0.4.0](https://github.com/lukso-network/universalprofile-smart-contracts/compare/v0.3.0...v0.4.0) (2021-11-26)
 
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -57,6 +57,10 @@ const config: HardhatUserConfig = {
       "LSP1UniversalReceiverDelegate",
       "LSP7Mintable",
       "LSP8Mintable",
+      "LSP7DigitalAsset",
+      "LSP7CappedSupply",
+      "LSP8IdentifiableDigitalAsset",
+      "LSP8CappedSupply",
       // Proxy version
       // ------------------
       "UniversalProfileInit",
@@ -64,6 +68,10 @@ const config: HardhatUserConfig = {
       "LSP1UniversalReceiverDelegateInit",
       "LSP7MintableInit",
       "LSP8MintableInit",
+      "LSP7DigitalAssetInit",
+      "LSP7CappedSupplyInit",
+      "LSP8IdentifiableDigitalAssetInit",
+      "LSP8CappedSupplyInit",
       // ERC Compatible tokens
       // ------------------
       "LSP7CompatibilityForERC20",

--- a/make-jar.sh
+++ b/make-jar.sh
@@ -43,11 +43,19 @@ FILES=(
     LSP1UniversalReceiverDelegate
     LSP7Mintable
     LSP8Mintable
+    LSP7DigitalAsset
+    LSP7CappedSupply
+    LSP8IdentifiableDigitalAsset
+    LSP8CappedSupply
     UniversalProfileInit
     LSP6KeyManagerInit
     LSP1UniversalReceiverDelegateInit
     LSP7MintableInit
     LSP8MintableInit
+    LSP7DigitalAssetInit
+    LSP7CappedSupplyInit
+    LSP8IdentifiableDigitalAssetInit
+    LSP8CappedSupplyInit
     LSP7CompatibilityForERC20
     LSP8CompatibilityForERC721
 )

--- a/make-jar.sh
+++ b/make-jar.sh
@@ -20,11 +20,19 @@ solc --abi --bin \
     contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegate.sol \
     contracts/LSP7DigitalAsset/extensions/LSP7Mintable.sol.sol \
     contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Mintable.sol.sol \
+    contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol \
+    contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol \
+    contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol \
+    contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol \
     contracts/UniversalProfileInit.sol \
     contracts/LSP6KeyManager/LSP6KeyManagerInit.sol \
     contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateInit.sol \
     contracts/LSP7DigitalAsset/extensions/LSP7MintableInit.sol.sol \
     contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8MintableInit.sol.sol \
+    contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol \
+    contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInit.sol \
+    contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInit.sol \
+    contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInit.sol \
     contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.sol \
     contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721.sol \
     -o ./output/

--- a/make-jar.sh
+++ b/make-jar.sh
@@ -18,8 +18,8 @@ solc --abi --bin \
     contracts/UniversalProfile.sol \
     contracts/LSP6KeyManager/LSP6KeyManager.sol \
     contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegate.sol \
-    contracts/LSP7DigitalAsset/extensions/LSP7Mintable.sol.sol \
-    contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Mintable.sol.sol \
+    contracts/LSP7DigitalAsset/extensions/LSP7Mintable.sol \
+    contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Mintable.sol \
     contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol \
     contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol \
     contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol \
@@ -27,8 +27,8 @@ solc --abi --bin \
     contracts/UniversalProfileInit.sol \
     contracts/LSP6KeyManager/LSP6KeyManagerInit.sol \
     contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateInit.sol \
-    contracts/LSP7DigitalAsset/extensions/LSP7MintableInit.sol.sol \
-    contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8MintableInit.sol.sol \
+    contracts/LSP7DigitalAsset/extensions/LSP7MintableInit.sol \
+    contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8MintableInit.sol \
     contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol \
     contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInit.sol \
     contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInit.sol \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lukso/universalprofile-smart-contracts",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lukso/universalprofile-smart-contracts",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lukso/universalprofile-smart-contracts",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The reference implementation for universal profiles smart contracts",
   "directories": {
     "test": "test"


### PR DESCRIPTION
Adds the `ADDPERMISSION` logic to the KeyManager and custom solidity errors.
Add `LSP7Mintable.sol` and `LSP8Mintable.sol`

Renamed smart contracts from e.g. `LSP7-DigitalAsset.sol` >  `LSP7DigitalAsset.sol`