### PR TITLE
ci: fix failing iOS CI for 0.4.1 release

### DIFF
--- a/.github/workflows/publish-ios-artifacts.yml
+++ b/.github/workflows/publish-ios-artifacts.yml
@@ -1,20 +1,20 @@
-# This workflow build and publish iOS artifacts
+# This workflow build and publish iOS artifacts to the LUKSO iOS SDK repository on Github
 
 name: Upload iOS Github artifacts CD
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "main"
 
 jobs:
-  ios-build-artifacts:
-    # The type of runner
+  upload-ios-artifacts:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
-      - name: Check if version changed
+      - name: Check if NPM package version has changed
         uses: EndBug/version-check@v1
         id: check
 
@@ -41,6 +41,7 @@ jobs:
           cd universalprofile-ios-sdk
           git config --global user.email "release@lukso.network"
           git config --global user.name "LUKSO Bot"
+          git push origin --delete abi-update-release
           git checkout -b abi-update-release
           cp ../ios/UPContractsAbi.swift universalprofile-ios-sdk/UPContractsAbi.swift
           git add .

--- a/.github/workflows/publish-ios-artifacts.yml
+++ b/.github/workflows/publish-ios-artifacts.yml
@@ -3,6 +3,7 @@
 name: Upload iOS Github artifacts CD
 
 on:
+  # Run workflow manually for testing
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/publish-ios-artifacts.yml
+++ b/.github/workflows/publish-ios-artifacts.yml
@@ -3,11 +3,11 @@
 name: Upload iOS Github artifacts CD
 
 on:
-  # Run workflow manually for testing
-  workflow_dispatch:
   push:
     branches:
       - "main"
+  # Run workflow manually for testing
+  workflow_dispatch:
 
 jobs:
   upload-ios-artifacts:

--- a/.github/workflows/publish-ios-artifacts.yml
+++ b/.github/workflows/publish-ios-artifacts.yml
@@ -3,9 +3,11 @@
 name: Upload iOS Github artifacts CD
 
 on:
-  push:
+  # push:
+  pull_request:
     branches:
-      - "main"
+      # - "main"
+      - "develop"
   # Run workflow manually for testing
   workflow_dispatch:
 

--- a/.github/workflows/publish-ios-artifacts.yml
+++ b/.github/workflows/publish-ios-artifacts.yml
@@ -3,12 +3,10 @@
 name: Upload iOS Github artifacts CD
 
 on:
-  # push:
-  pull_request:
+  push:
     branches:
-      # - "main"
-      - "develop"
-  # Run workflow manually for testing
+      - "main"
+  # Enable to run workflow manually for debugging
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# What does this PR introduce?

Fix conflict with new branch of same name with updated artifacts, when pushing new branch to origin.

-> Update iOS release CI to delete branch `abi-update-release` at the origin (`universal-profiles-ios-sdk`) before push.