### PR TITLE
test: remove deprecated key `SupportedStandards:LSP4DigitalCertificate`

### DIFF
--- a/tests/utils/constants.ts
+++ b/tests/utils/constants.ts
@@ -15,7 +15,7 @@ export const enum INTERFACE_IDS {
   LSP6 = "0x6f4df48b",
   LSP7 = "0xe33f65c3",
   LSP8 = "0x49399145",
-  LSP9 = "0x75edcee5"
+  LSP9 = "0x75edcee5",
 }
 
 // ERC725Y
@@ -25,10 +25,6 @@ export const SupportedStandards = {
   LSP3UniversalProfile: {
     key: "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
     value: "0xabe425d6",
-  },
-  LSP4DigitalCertificate: {
-    key: "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abf0613c",
-    value: "0xabf0613c",
   },
   LSP4DigitalAsset: {
     key: "0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624",
@@ -48,21 +44,25 @@ export const ERC725YKeys = {
   },
   LSP3: {
     // keccak256('LSP3Profile')
-    LSP3Profile: "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
+    LSP3Profile:
+      "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
     // LSP3IssuedAssetsMap:<address> --> bytes
     "LSP3IssuedAssetsMap:": "0x83f5e77bfb14241600000000",
     // keccak256('LSP3IssuedAssets[]')
-    "LSP3IssuedAssets[]": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
+    "LSP3IssuedAssets[]":
+      "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
   },
   LSP5: {
     // LSP5ReceivedAssetsMap:<address>
     "LSP5ReceivedAssetsMap:": "0x812c4334633eb81600000000",
     // LSP5ReceivedAssets[]
-    "LSP5ReceivedAssets[]": "0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b",
+    "LSP5ReceivedAssets[]":
+      "0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b",
   },
   LSP6: {
     // AddressPermissions[]
-    "AddressPermissions[]": "0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3",
+    "AddressPermissions[]":
+      "0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3",
     // AddressPermissions:Permissions:<address> --> bytes1
     "AddressPermissions:Permissions:": "0x4b80742d0000000082ac0000",
     // AddressPermissions:AllowedAddresses:<address> --> address[]
@@ -71,9 +71,10 @@ export const ERC725YKeys = {
     "AddressPermissions:AllowedFunctions:": "0x4b80742d000000008efe0000",
   },
   LSP10: {
-    "LSP10ReceivedVaultsMap": "0x5e5a4636eeb20bf100000000",
-    "LSP10ReceivedVaults[]": "0xd8c6ec2b958bbebb976719e1eb233f126e0f355c63843f434220f9753b5ca9e5"
-  }
+    LSP10ReceivedVaultsMap: "0x5e5a4636eeb20bf100000000",
+    "LSP10ReceivedVaults[]":
+      "0xd8c6ec2b958bbebb976719e1eb233f126e0f355c63843f434220f9753b5ca9e5",
+  },
 };
 
 export const BasicUPSetup_Schema: ERC725JSONSchema[] = [
@@ -115,7 +116,8 @@ export const EventSignatures = {
    *
    * signature = keccak256('UniversalReceiver(address,bytes32,bytes32,bytes)')
    */
-  UniversalReceiver: "0x8187df79ab47ad16102e7bc8760349a115b3ba9869b8cedd78996f930ac9cac3",
+  UniversalReceiver:
+    "0x8187df79ab47ad16102e7bc8760349a115b3ba9869b8cedd78996f930ac9cac3",
   /**
    * event ReceivedERC777(
    *    address indexed token,
@@ -127,7 +129,8 @@ export const EventSignatures = {
    *
    * signature = keccak256('ReceivedERC777(address,address,address,address,uint256)')
    */
-  ReceivedERC777: "0xdc38539587ea4d67f9f649ad9269646bab26927bad175bdcdfdab5dd297d5e1c",
+  ReceivedERC777:
+    "0xdc38539587ea4d67f9f649ad9269646bab26927bad175bdcdfdab5dd297d5e1c",
 };
 
 // LSP0
@@ -146,7 +149,9 @@ export const enum OPERATIONS {
 
 // hex =    0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 // binary = .... 1111 1111 1111 (only 1s)
-export const ALL_PERMISSIONS_SET = ethers.utils.hexlify(ethers.constants.MaxUint256);
+export const ALL_PERMISSIONS_SET = ethers.utils.hexlify(
+  ethers.constants.MaxUint256
+);
 
 // prettier-ignore
 export const enum PERMISSIONS {


### PR DESCRIPTION
Removed this key from the constant file in the tests, so that we don't use it by mistake.