### PR TITLE
perf: sav gas in the KeyManager

### DIFF
--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -140,7 +140,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
     ) external payable override returns (bytes memory) {
         require(
             _signedFor == address(this),
-            "KeyManager:executeRelayCall: Message not signed for this keyManager"
+            "executeRelayCall: Message not signed for this keyManager"
         );
 
         bytes memory blob = abi.encodePacked(
@@ -155,7 +155,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
 
         require(
             _isValidNonce(signer, _nonce),
-            "KeyManager:executeRelayCall: Incorrect nonce"
+            "executeRelayCall: Incorrect nonce"
         );
 
         // increase nonce after successful verification
@@ -233,7 +233,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
                 _notAuthorised(_from, "TRANSFEROWNERSHIP");
         } else {
             revert(
-                "KeyManager:_verifyPermissions: unknown function selector on ERC725 account"
+                "_verifyPermissions: unknown function selector on ERC725 account"
             );
         }
     }
@@ -298,7 +298,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
 
         require(
             operationType != 4,
-            "KeyManager:_verifyCanExecute: operation 4 `DELEGATECALL` not supported"
+            "_verifyCanExecute: operation 4 `DELEGATECALL` not supported"
         );
 
         (
@@ -395,7 +395,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
     {
         require(
             _operationType < 5,
-            "KeyManager:_extractPermissionFromOperation: invalid operation type"
+            "_extractPermissionFromOperation: invalid operation type"
         );
 
         if (_operationType == 0) return (_PERMISSION_CALL, "CALL");

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -155,7 +155,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
 
         require(
             _isValidNonce(signer, _nonce),
-            "executeRelayCall: Incorrect nonce"
+            "executeRelayCall: Invalid nonce"
         );
 
         // increase nonce after successful verification
@@ -232,9 +232,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165Storage {
             _hasPermission(_PERMISSION_CHANGEOWNER, permissions) ||
                 _notAuthorised(_from, "TRANSFEROWNERSHIP");
         } else {
-            revert(
-                "_verifyPermissions: unknown function selector on ERC725 account"
-            );
+            revert("_verifyPermissions: unknown ERC725 selector");
         }
     }
 

--- a/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
@@ -527,7 +527,7 @@ describe("KeyManager", () => {
       await expect(
         keyManager.connect(owner).execute(executePayload)
       ).toBeRevertedWith(
-        "KeyManager:_verifyCanExecute: operation 4 `DELEGATECALL` not supported"
+        "_verifyCanExecute: operation 4 `DELEGATECALL` not supported"
       );
     });
 
@@ -902,7 +902,7 @@ describe("KeyManager", () => {
       ]);
 
       await expect(keyManager.execute(payload)).toBeRevertedWith(
-        "KeyManager:_extractPermissionFromOperation: invalid operation type"
+        "_extractPermissionFromOperation: invalid operation type"
       );
     });
 
@@ -910,7 +910,7 @@ describe("KeyManager", () => {
       await expect(
         keyManager.execute("0xbad000000000000000000000000bad")
       ).toBeRevertedWith(
-        "KeyManager:_verifyPermissions: unknown function selector on ERC725 account"
+        "_verifyPermissions: unknown ERC725 selector"
       );
     });
 
@@ -1633,7 +1633,7 @@ describe("KeyManager", () => {
           nonce,
           signature
         )
-      ).toBeRevertedWith("KeyManager:executeRelayCall: Incorrect nonce");
+      ).toBeRevertedWith("KeyManager:executeRelayCall: Invalid nonce");
     });
   });
 });

--- a/tests/LSP6KeyManager/LSP6KeyManagerProxy.spec.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManagerProxy.spec.ts
@@ -527,7 +527,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       await expect(
         proxyKeyManager.connect(owner).execute(executePayload)
       ).toBeRevertedWith(
-        "KeyManager:_verifyCanExecute: operation 4 `DELEGATECALL` not supported"
+        "_verifyCanExecute: operation 4 `DELEGATECALL` not supported"
       );
     });
 
@@ -902,7 +902,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       );
 
       await expect(proxyKeyManager.execute(payload)).toBeRevertedWith(
-        "KeyManager:_extractPermissionFromOperation: invalid operation type"
+        "_extractPermissionFromOperation: invalid operation type"
       );
     });
 
@@ -910,7 +910,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
       await expect(
         proxyKeyManager.execute("0xbad000000000000000000000000bad")
       ).toBeRevertedWith(
-        "KeyManager:_verifyPermissions: unknown function selector on ERC725 account"
+        "_verifyPermissions: unknown ERC725 selector"
       );
     });
 
@@ -1632,7 +1632,7 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
           executeRelayCallPayload,
           signature
         )
-      ).toBeRevertedWith("KeyManager:executeRelayCall: Incorrect nonce");
+      ).toBeRevertedWith("executeRelayCall: Invalid nonce");
     });
   });
 });


### PR DESCRIPTION
# What Changes this PR introduce 
Save gas on deployment by shortening the revert messgae in the require statement.
Removing **KeyManager:** on each message won't affect the context.
⬇️ Saves 30,435 gas ⬇️ | deployed on L14 
- Link to the normal KeyManager on Blockscout:  https://blockscout.com/lukso/l14/tx/0xe65c411f925f3b2e2aa613abbc99624c777c5581d95ccb09db23f278517e472c/internal-transactions
- Link to the Optimzed KeyManager on Blockscout:  https://blockscout.com/lukso/l14/tx/0x189b1d378db858fbe067864256c0d3724aea21176f934f96f25e8e9d10e46b5e/internal-transactions

