### PR TITLE
refactor: use constants for interfaceIds in Solidity

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 import "./ILSP6KeyManager.sol";
 
 // --- ERC165 interface ids
-bytes4 constant _INTERFACEID_LSP6 = type(ILSP6KeyManager).interfaceId;
+bytes4 constant _INTERFACEID_LSP6 = 0x6f4df48b;
 
 /* solhint-disable */
 // PERMISSION KEYS

--- a/tests/LSP9Vault/LSP9Vault.spec.ts
+++ b/tests/LSP9Vault/LSP9Vault.spec.ts
@@ -17,14 +17,14 @@ import {
   SupportedStandards,
   INTERFACE_IDS,
   ERC725YKeys,
-  OPERATIONS
+  OPERATIONS,
 } from "../utils/constants";
 
 import {
   RANDOM_BYTES32,
   DUMMY_PAYLOAD,
   getMapAndArrayKeyValues,
-  LSP10_ARRAY_KEY
+  LSP10_ARRAY_KEY,
 } from "../utils/helpers";
 
 describe("LSP9Vault", () => {
@@ -49,7 +49,7 @@ describe("LSP9Vault", () => {
 
   describe("ERC165", () => {
     it("Supports ERC165", async () => {
-      const interfaceID = "0x01ffc9a7";
+      const interfaceID = INTERFACE_IDS.ERC165;
       const result = await LSP9Vault.callStatic.supportsInterface(interfaceID);
 
       expect(result).toBeTruthy();

--- a/tests/UniversalProfile.spec.ts
+++ b/tests/UniversalProfile.spec.ts
@@ -21,6 +21,7 @@ import {
 
 // constants
 import {
+  INTERFACE_IDS,
   SupportedStandards,
   ERC725YKeys,
   EventSignatures,
@@ -42,7 +43,9 @@ describe("UniversalProfile", () => {
   beforeAll(async () => {
     accounts = await ethers.getSigners();
     owner = accounts[2];
-    UniversalProfile = await new UniversalProfile__factory(owner).deploy(owner.address);
+    UniversalProfile = await new UniversalProfile__factory(owner).deploy(
+      owner.address
+    );
   });
 
   describe("Accounts Deployment", () => {
@@ -54,36 +57,46 @@ describe("UniversalProfile", () => {
 
   describe("ERC165", () => {
     it("Supports ERC165", async () => {
-      const interfaceID = "0x01ffc9a7";
-      const result = await UniversalProfile.callStatic.supportsInterface(interfaceID);
+      const interfaceID = INTERFACE_IDS.ERC165;
+      const result = await UniversalProfile.callStatic.supportsInterface(
+        interfaceID
+      );
 
       expect(result).toBeTruthy();
     });
 
     it("Supports ERC725X", async () => {
-      const interfaceID = "0x44c028fe";
-      const result = await UniversalProfile.callStatic.supportsInterface(interfaceID);
+      const interfaceID = INTERFACE_IDS.ERC725X;
+      const result = await UniversalProfile.callStatic.supportsInterface(
+        interfaceID
+      );
 
       expect(result).toBeTruthy();
     });
 
     it("Supports ERC725Y", async () => {
-      const interfaceID = "0x5a988c0f";
-      const result = await UniversalProfile.callStatic.supportsInterface(interfaceID);
+      const interfaceID = INTERFACE_IDS.ERC725Y;
+      const result = await UniversalProfile.callStatic.supportsInterface(
+        interfaceID
+      );
 
       expect(result).toBeTruthy();
     });
 
     it("Supports ERC1271", async () => {
-      const interfaceID = "0x1626ba7e";
-      const result = await UniversalProfile.callStatic.supportsInterface(interfaceID);
+      const interfaceID = INTERFACE_IDS.ERC1271;
+      const result = await UniversalProfile.callStatic.supportsInterface(
+        interfaceID
+      );
 
       expect(result).toBeTruthy();
     });
 
     it("Supports LSP1", async () => {
-      const interfaceID = "0x6bb56a14";
-      const result = await UniversalProfile.callStatic.supportsInterface(interfaceID);
+      const interfaceID = INTERFACE_IDS.LSP1;
+      const result = await UniversalProfile.callStatic.supportsInterface(
+        interfaceID
+      );
 
       expect(result).toBeTruthy();
     });
@@ -100,13 +113,18 @@ describe("UniversalProfile", () => {
   describe("ERC1271", () => {
     it("Can verify signature from owner", async () => {
       const signer = accounts[9];
-      const account = await new UniversalProfile__factory(owner).deploy(signer.address);
+      const account = await new UniversalProfile__factory(owner).deploy(
+        signer.address
+      );
 
       const dataToSign = "0xcafecafe";
       const messageHash = ethers.utils.hashMessage(dataToSign);
       const signature = await signer.signMessage(dataToSign);
 
-      const result = await account.callStatic.isValidSignature(messageHash, signature);
+      const result = await account.callStatic.isValidSignature(
+        messageHash,
+        signature
+      );
       expect(result).toEqual(ERC1271.MAGIC_VALUE);
     });
 
@@ -114,12 +132,17 @@ describe("UniversalProfile", () => {
       const owner = accounts[2];
       const signer = accounts[9];
 
-      const account = await new UniversalProfile__factory(owner).deploy(owner.address);
+      const account = await new UniversalProfile__factory(owner).deploy(
+        owner.address
+      );
       const dataToSign = "0xcafecafe";
       const messageHash = ethers.utils.hashMessage(dataToSign);
       const signature = await signer.signMessage(dataToSign);
 
-      const result = await account.callStatic.isValidSignature(messageHash, signature);
+      const result = await account.callStatic.isValidSignature(
+        messageHash,
+        signature
+      );
       expect(result).toEqual(ERC1271.FAIL_VALUE);
     });
   });
@@ -130,7 +153,9 @@ describe("UniversalProfile", () => {
 
     it("Create account", async () => {
       const owner = accounts[2];
-      const newaccount = await new UniversalProfile__factory(owner).deploy(owner.address);
+      const newaccount = await new UniversalProfile__factory(owner).deploy(
+        owner.address
+      );
 
       expect(await newaccount.callStatic.owner()).toEqual(owner.address);
     });
@@ -288,7 +313,9 @@ describe("UniversalProfile", () => {
     beforeEach(async () => {
       owner = accounts[3];
       newOwner = accounts[5];
-      account = await new UniversalProfile__factory(owner).deploy(owner.address);
+      account = await new UniversalProfile__factory(owner).deploy(
+        owner.address
+      );
     });
 
     it("Upgrade ownership correctly", async () => {
@@ -299,9 +326,9 @@ describe("UniversalProfile", () => {
     });
 
     it("Refuse upgrades from non-onwer", async () => {
-      await expect(account.connect(newOwner).transferOwnership(newOwner.address)).toBeRevertedWith(
-        "Ownable: caller is not the owner"
-      );
+      await expect(
+        account.connect(newOwner).transferOwnership(newOwner.address)
+      ).toBeRevertedWith("Ownable: caller is not the owner");
     });
 
     it("Owner can set data", async () => {
@@ -314,7 +341,9 @@ describe("UniversalProfile", () => {
           ),
         ]
       );
-      let data = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Important Data"));
+      let data = ethers.utils.hexlify(
+        ethers.utils.toUtf8Bytes("Important Data")
+      );
 
       await account.connect(owner).setData([key], [data]);
 
@@ -333,11 +362,13 @@ describe("UniversalProfile", () => {
           ),
         ]
       );
-      let data = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Important Data"));
-
-      await expect(account.connect(newOwner).setData([key], [data])).toBeRevertedWith(
-        "Ownable: caller is not the owner"
+      let data = ethers.utils.hexlify(
+        ethers.utils.toUtf8Bytes("Important Data")
       );
+
+      await expect(
+        account.connect(newOwner).setData([key], [data])
+      ).toBeRevertedWith("Ownable: caller is not the owner");
     });
 
     it("Fails when non-owner sets data", async () => {
@@ -350,11 +381,13 @@ describe("UniversalProfile", () => {
           ),
         ]
       );
-      let data = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Important Data"));
-
-      await expect(account.connect(newOwner).setData([key], [data])).toBeRevertedWith(
-        "Ownable: caller is not the owner"
+      let data = ethers.utils.hexlify(
+        ethers.utils.toUtf8Bytes("Important Data")
       );
+
+      await expect(
+        account.connect(newOwner).setData([key], [data])
+      ).toBeRevertedWith("Ownable: caller is not the owner");
     });
 
     it("Allows owner to execute calls", async () => {
@@ -368,7 +401,9 @@ describe("UniversalProfile", () => {
 
       const destBalance = await provider.getBalance(dest.address);
 
-      await account.connect(owner).execute(OPERATIONS.CALL, dest.address, amount, "0x00");
+      await account
+        .connect(owner)
+        .execute(OPERATIONS.CALL, dest.address, amount, "0x00");
 
       const finalBalance = await provider.getBalance(dest.address);
 
@@ -389,7 +424,9 @@ describe("UniversalProfile", () => {
 
       // try to move it away
       await expect(
-        account.connect(newOwner).execute(OPERATIONS.CALL, dest.address, amount, "0x")
+        account
+          .connect(newOwner)
+          .execute(OPERATIONS.CALL, dest.address, amount, "0x")
       ).toBeRevertedWith("Ownable: caller is not the owner");
     });
 
@@ -410,10 +447,15 @@ describe("UniversalProfile", () => {
     // TODO test delegateCall
 
     it("Allows owner to execute create2", async () => {
-      let salt = "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
+      let salt =
+        "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
       let contractBytecode =
         "0x608060405234801561001057600080fd5b506040516105f93803806105f98339818101604052602081101561003357600080fd5b810190808051906020019092919050505080600160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555050610564806100956000396000f3fe60806040526004361061003f5760003560e01c806344c028fe1461004157806354f6127f146100fb578063749ebfb81461014a5780638da5cb5b1461018f575b005b34801561004d57600080fd5b506100f96004803603608081101561006457600080fd5b8101908080359060200190929190803573ffffffffffffffffffffffffffffffffffffffff16906020019092919080359060200190929190803590602001906401000000008111156100b557600080fd5b8201836020820111156100c757600080fd5b803590602001918460018302840111640100000000831117156100e957600080fd5b90919293919293905050506101e6565b005b34801561010757600080fd5b506101346004803603602081101561011e57600080fd5b81019080803590602001909291905050506103b7565b6040518082815260200191505060405180910390f35b34801561015657600080fd5b5061018d6004803603604081101561016d57600080fd5b8101908080359060200190929190803590602001909291905050506103d3565b005b34801561019b57600080fd5b506101a46104df565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16146102a9576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260128152602001807f6f6e6c792d6f776e65722d616c6c6f776564000000000000000000000000000081525060200191505060405180910390fd5b600085141561030757610301848484848080601f016020809104026020016040519081016040528093929190818152602001838380828437600081840152601f19601f82011690508083019250505050505050610505565b506103b0565b60018514156103aa57600061035f83838080601f016020809104026020016040519081016040528093929190818152602001838380828437600081840152601f19601f8201169050808301925050505050505061051d565b90508073ffffffffffffffffffffffffffffffffffffffff167fcf78cf0d6f3d8371e1075c69c492ab4ec5d8cf23a1a239b6a51a1d00be7ca31260405160405180910390a2506103af565b600080fd5b5b5050505050565b6000806000838152602001908152602001600020549050919050565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614610496576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260128152602001807f6f6e6c792d6f776e65722d616c6c6f776564000000000000000000000000000081525060200191505060405180910390fd5b806000808481526020019081526020016000208190555080827f35553580e4553c909abeb5764e842ce1f93c45f9f614bde2a2ca5f5b7b7dc0fb60405160405180910390a35050565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b600080600083516020850186885af190509392505050565b60008151602083016000f0905091905056fea265627a7a723158207fb9c8d804ca4e17aec99dbd7aab0a61583b56ebcbcb7e05589f97043968644364736f6c634300051100320000000000000000000000009501234ef8368466383d698c7fe7bd5ded85b4f6";
-      let preComputedAddress = calculateCreate2(account.address, salt, contractBytecode);
+      let preComputedAddress = calculateCreate2(
+        account.address,
+        salt,
+        contractBytecode
+      );
 
       // deploy with added 32 bytes salt
       let transaction = await account.connect(owner).execute(
@@ -427,7 +469,9 @@ describe("UniversalProfile", () => {
       let receipt = await transaction.wait();
 
       expect(receipt.events[0].event).toEqual("ContractCreated");
-      expect(receipt.events[0].args._contractAddress).toEqual(preComputedAddress);
+      expect(receipt.events[0].args._contractAddress).toEqual(
+        preComputedAddress
+      );
     });
 
     it("Allow account to receive native tokens", async () => {
@@ -451,11 +495,12 @@ describe("UniversalProfile", () => {
      */
     it("Call account and check for 'UniversalReceiver' event", async () => {
       const owner = accounts[2];
-      const account = await new UniversalProfile__factory(owner).deploy(owner.address);
+      const account = await new UniversalProfile__factory(owner).deploy(
+        owner.address
+      );
       // use the checker contract to call account
-      let checker: UniversalReceiverTester = await new UniversalReceiverTester__factory(
-        owner
-      ).deploy();
+      let checker: UniversalReceiverTester =
+        await new UniversalReceiverTester__factory(owner).deploy();
 
       let transaction = await checker
         .connect(owner)
@@ -465,7 +510,9 @@ describe("UniversalProfile", () => {
       // event should come from account
       expect(receipt.logs[0].address).toEqual(account.address);
       // event signature
-      expect(receipt.logs[0].topics[0]).toEqual(EventSignatures.UniversalReceiver);
+      expect(receipt.logs[0].topics[0]).toEqual(
+        EventSignatures.UniversalReceiver
+      );
       // from
       expect(receipt.logs[0].topics[1]).toEqual(
         ethers.utils.hexZeroPad(checker.address.toLowerCase(), 32)
@@ -485,9 +532,13 @@ describe("UniversalProfile", () => {
      */
     it("Call account and check for 'ReceivedERC777' event in external account", async () => {
       const owner = accounts[2];
-      const account = await new UniversalProfile__factory(owner).deploy(owner.address);
+      const account = await new UniversalProfile__factory(owner).deploy(
+        owner.address
+      );
       const externalUniversalReceiver: ExternalERC777UniversalReceiverTester =
-        await new ExternalERC777UniversalReceiverTester__factory(owner).deploy();
+        await new ExternalERC777UniversalReceiverTester__factory(
+          owner
+        ).deploy();
 
       // set account2 as new receiver for account1
       await account
@@ -498,9 +549,8 @@ describe("UniversalProfile", () => {
         );
 
       // use the checker contract to call account
-      let checker: UniversalReceiverTester = await new UniversalReceiverTester__factory(
-        owner
-      ).deploy();
+      let checker: UniversalReceiverTester =
+        await new UniversalReceiverTester__factory(owner).deploy();
       let transaction = await checker.callImplementationAndReturn(
         account.address,
         ERC777TokensRecipient
@@ -509,12 +559,17 @@ describe("UniversalProfile", () => {
 
       console.log("accounts[2] (owner): ", owner.address);
       console.log("account (UP): ", account.address);
-      console.log("externalUniversalReceiver: ", externalUniversalReceiver.address);
+      console.log(
+        "externalUniversalReceiver: ",
+        externalUniversalReceiver.address
+      );
       console.log("checker: ", checker.address);
 
       // event signature "event ReceivedERC777(address indexed token, address indexed _operator, address indexed _from, address _to, uint256 _amount)"
       // event should come from account externalUniversalReceiver
-      expect(receipt.logs[0].address).toEqual(externalUniversalReceiver.address);
+      expect(receipt.logs[0].address).toEqual(
+        externalUniversalReceiver.address
+      );
       // signature
       expect(receipt.logs[0].topics[0]).toEqual(
         "0xdc38539587ea4d67f9f649ad9269646bab26927bad175bdcdfdab5dd297d5e1c"
@@ -534,7 +589,9 @@ describe("UniversalProfile", () => {
       // event should come from account account
       expect(receipt.logs[1].address).toEqual(account.address);
       // signature
-      expect(receipt.logs[1].topics[0]).toEqual(EventSignatures.UniversalReceiver);
+      expect(receipt.logs[1].topics[0]).toEqual(
+        EventSignatures.UniversalReceiver
+      );
       // "from" is the checker
       expect(receipt.logs[1].topics[1]).toEqual(
         ethers.utils.hexZeroPad(checker.address.toLowerCase(), 32)
@@ -549,77 +606,123 @@ describe("UniversalProfile", () => {
 
     it("Mint ERC777 and LSP4 to LSP3 account", async () => {
       const owner = accounts[2];
-      const account = await new UniversalProfile__factory(owner).deploy(owner.address);
+      const account = await new UniversalProfile__factory(owner).deploy(
+        owner.address
+      );
       const universalReceiverDelegate: UniversalReceiverAddressStore =
-        await new UniversalReceiverAddressStore__factory(owner).deploy(owner.address);
+        await new UniversalReceiverAddressStore__factory(owner).deploy(
+          owner.address
+        );
 
       let tokenOwner = accounts[2];
 
-      let erc777: ERC777UniversalReceiver = await new ERC777UniversalReceiver__factory(
-        owner
-      ).deploy("MyToken", "TKN", [tokenOwner.address]);
-      let digitalCertificate: LSP4DigitalCertificate = await new LSP4DigitalCertificate__factory(
-        owner
-      ).deploy(tokenOwner.address, "MyDigitalCloth", "DIGICLOTH01", []);
+      let erc777: ERC777UniversalReceiver =
+        await new ERC777UniversalReceiver__factory(owner).deploy(
+          "MyToken",
+          "TKN",
+          [tokenOwner.address]
+        );
+      let digitalCertificate: LSP4DigitalCertificate =
+        await new LSP4DigitalCertificate__factory(owner).deploy(
+          tokenOwner.address,
+          "MyDigitalCloth",
+          "DIGICLOTH01",
+          []
+        );
 
       let initialERC777Balance = await erc777.balanceOf(account.address);
-      let initialdigitalCertificateBalance = await digitalCertificate.balanceOf(account.address);
+      let initialdigitalCertificateBalance = await digitalCertificate.balanceOf(
+        account.address
+      );
       expect(ethers.BigNumber.from(initialERC777Balance).toNumber()).toEqual(0);
-      expect(ethers.BigNumber.from(initialdigitalCertificateBalance).toNumber()).toEqual(0);
+      expect(
+        ethers.BigNumber.from(initialdigitalCertificateBalance).toNumber()
+      ).toEqual(0);
 
       await erc777.mint(account.address, "50", { from: tokenOwner.address });
       let newERC777Balance = await erc777.balanceOf(account.address);
       expect(ethers.BigNumber.from(newERC777Balance).toNumber()).toEqual(50);
 
-      await digitalCertificate.mint(account.address, "50", { from: tokenOwner.address });
-      let newDigitalCertificateBalance = await digitalCertificate.balanceOf(account.address);
-      expect(ethers.BigNumber.from(newDigitalCertificateBalance).toNumber()).toEqual(50);
+      await digitalCertificate.mint(account.address, "50", {
+        from: tokenOwner.address,
+      });
+      let newDigitalCertificateBalance = await digitalCertificate.balanceOf(
+        account.address
+      );
+      expect(
+        ethers.BigNumber.from(newDigitalCertificateBalance).toNumber()
+      ).toEqual(50);
     });
 
     it("Transfer ERC777 and LSP4 to LSP3 account", async () => {
       const owner = accounts[2];
-      const account = await new UniversalProfile__factory(owner).deploy(owner.address);
+      const account = await new UniversalProfile__factory(owner).deploy(
+        owner.address
+      );
       const universalReceiverDelegate: UniversalReceiverAddressStore =
-        await new UniversalReceiverAddressStore__factory(owner).deploy(account.address);
+        await new UniversalReceiverAddressStore__factory(owner).deploy(
+          account.address
+        );
 
       let tokenOwner = accounts[3];
 
-      let erc777: ERC777UniversalReceiver = await new ERC777UniversalReceiver__factory(
-        owner
-      ).deploy("MyToken", "TKN", [tokenOwner.address]);
-      let digitalCertificate: LSP4DigitalCertificate = await new LSP4DigitalCertificate__factory(
-        owner
-      ).deploy(tokenOwner.address, "MyDigitalCloth", "DIGICLOTH01", []);
+      let erc777: ERC777UniversalReceiver =
+        await new ERC777UniversalReceiver__factory(owner).deploy(
+          "MyToken",
+          "TKN",
+          [tokenOwner.address]
+        );
+      let digitalCertificate: LSP4DigitalCertificate =
+        await new LSP4DigitalCertificate__factory(owner).deploy(
+          tokenOwner.address,
+          "MyDigitalCloth",
+          "DIGICLOTH01",
+          []
+        );
 
       await erc777.connect(tokenOwner).mint(tokenOwner.address, "100");
-      await digitalCertificate.connect(tokenOwner).mint(tokenOwner.address, "100");
+      await digitalCertificate
+        .connect(tokenOwner)
+        .mint(tokenOwner.address, "100");
 
-      let initialERC777Balance = await erc777.callStatic.balanceOf(account.address);
-      let initialdigitalCertificateBalance = await digitalCertificate.callStatic.balanceOf(
+      let initialERC777Balance = await erc777.callStatic.balanceOf(
         account.address
       );
+      let initialdigitalCertificateBalance =
+        await digitalCertificate.callStatic.balanceOf(account.address);
 
       expect(ethers.BigNumber.from(initialERC777Balance).toNumber()).toEqual(0);
-      expect(ethers.BigNumber.from(initialdigitalCertificateBalance).toNumber()).toEqual(0);
+      expect(
+        ethers.BigNumber.from(initialdigitalCertificateBalance).toNumber()
+      ).toEqual(0);
 
       await erc777.connect(tokenOwner).send(account.address, "50", "0x");
       await erc777.connect(tokenOwner).transfer(account.address, "50");
-      await digitalCertificate.connect(tokenOwner).send(account.address, "50", "0x");
-      await digitalCertificate.connect(tokenOwner).transfer(account.address, "50");
+      await digitalCertificate
+        .connect(tokenOwner)
+        .send(account.address, "50", "0x");
+      await digitalCertificate
+        .connect(tokenOwner)
+        .transfer(account.address, "50");
 
       let newERC777Balance = await erc777.callStatic.balanceOf(account.address);
-      let newdigitalCertificateBalance = await digitalCertificate.callStatic.balanceOf(
-        account.address
-      );
+      let newdigitalCertificateBalance =
+        await digitalCertificate.callStatic.balanceOf(account.address);
       expect(ethers.BigNumber.from(newERC777Balance).toNumber()).toEqual(100);
-      expect(ethers.BigNumber.from(newdigitalCertificateBalance).toNumber()).toEqual(100);
+      expect(
+        ethers.BigNumber.from(newdigitalCertificateBalance).toNumber()
+      ).toEqual(100);
     });
 
     it("Mint ERC777 and LSP4 to LSP3 account and delegate to UniversalReceiverAddressStore", async () => {
       const owner = accounts[2];
-      const account = await new UniversalProfile__factory(owner).deploy(owner.address);
+      const account = await new UniversalProfile__factory(owner).deploy(
+        owner.address
+      );
       const universalReceiverDelegate: UniversalReceiverAddressStore =
-        await new UniversalReceiverAddressStore__factory(owner).deploy(account.address);
+        await new UniversalReceiverAddressStore__factory(owner).deploy(
+          account.address
+        );
 
       // set account2 as new receiver for account1
       await account
@@ -631,12 +734,19 @@ describe("UniversalProfile", () => {
 
       let tokenOwner = accounts[2];
 
-      let erc777: ERC777UniversalReceiver = await new ERC777UniversalReceiver__factory(
-        owner
-      ).deploy("MyToken", "TKN", [tokenOwner.address]);
-      let digitalCertificate: LSP4DigitalCertificate = await new LSP4DigitalCertificate__factory(
-        owner
-      ).deploy(tokenOwner.address, "MyDigitalCloth", "DIGICLOTH01", []);
+      let erc777: ERC777UniversalReceiver =
+        await new ERC777UniversalReceiver__factory(owner).deploy(
+          "MyToken",
+          "TKN",
+          [tokenOwner.address]
+        );
+      let digitalCertificate: LSP4DigitalCertificate =
+        await new LSP4DigitalCertificate__factory(owner).deploy(
+          tokenOwner.address,
+          "MyDigitalCloth",
+          "DIGICLOTH01",
+          []
+        );
 
       expect(await erc777.balanceOf(account.address)).toEqBN(0);
       expect(await digitalCertificate.balanceOf(account.address)).toEqBN(0);
@@ -647,17 +757,25 @@ describe("UniversalProfile", () => {
       await digitalCertificate.connect(tokenOwner).mint(account.address, "50");
       expect(await digitalCertificate.balanceOf(account.address)).toEqBN(50);
 
-      expect(await universalReceiverDelegate.containsAddress(erc777.address)).toBeTruthy();
       expect(
-        await universalReceiverDelegate.containsAddress(digitalCertificate.address)
+        await universalReceiverDelegate.containsAddress(erc777.address)
+      ).toBeTruthy();
+      expect(
+        await universalReceiverDelegate.containsAddress(
+          digitalCertificate.address
+        )
       ).toBeTruthy();
     });
 
     it("Transfer ERC777 and LSP4 from LSP3 account with delegate to UniversalReceiverAddressStore", async () => {
       const owner = accounts[2];
-      const account = await new UniversalProfile__factory(owner).deploy(owner.address);
+      const account = await new UniversalProfile__factory(owner).deploy(
+        owner.address
+      );
       const universalReceiverDelegate: UniversalReceiverAddressStore =
-        await new UniversalReceiverAddressStore__factory(owner).deploy(account.address);
+        await new UniversalReceiverAddressStore__factory(owner).deploy(
+          account.address
+        );
 
       // set account2 as new receiver for account1
       await account
@@ -669,41 +787,58 @@ describe("UniversalProfile", () => {
 
       let tokenOwner = accounts[2];
 
-      let erc777: ERC777UniversalReceiver = await new ERC777UniversalReceiver__factory(
-        owner
-      ).deploy("MyToken", "TKN", [tokenOwner.address]);
-      let digitalCertificate: LSP4DigitalCertificate = await new LSP4DigitalCertificate__factory(
-        owner
-      ).deploy(tokenOwner.address, "MyDigitalCloth", "DIGICLOTH01", []);
+      let erc777: ERC777UniversalReceiver =
+        await new ERC777UniversalReceiver__factory(owner).deploy(
+          "MyToken",
+          "TKN",
+          [tokenOwner.address]
+        );
+      let digitalCertificate: LSP4DigitalCertificate =
+        await new LSP4DigitalCertificate__factory(owner).deploy(
+          tokenOwner.address,
+          "MyDigitalCloth",
+          "DIGICLOTH01",
+          []
+        );
 
       await erc777.connect(tokenOwner).mint(tokenOwner.address, "100");
-      await digitalCertificate.connect(tokenOwner).mint(tokenOwner.address, "100");
+      await digitalCertificate
+        .connect(tokenOwner)
+        .mint(tokenOwner.address, "100");
 
       expect(await erc777.balanceOf(account.address)).toEqBN(0);
       expect(await digitalCertificate.balanceOf(account.address)).toEqBN(0);
 
       await erc777.connect(tokenOwner).send(account.address, "50", "0x");
       await erc777.connect(tokenOwner).transfer(account.address, "50");
-      await digitalCertificate.connect(tokenOwner).send(account.address, "50", "0x");
-      await digitalCertificate.connect(tokenOwner).transfer(account.address, "50");
+      await digitalCertificate
+        .connect(tokenOwner)
+        .send(account.address, "50", "0x");
+      await digitalCertificate
+        .connect(tokenOwner)
+        .transfer(account.address, "50");
 
       expect(await erc777.balanceOf(account.address)).toEqBN("100");
       expect(await digitalCertificate.balanceOf(account.address)).toEqBN("100");
 
-      expect(await universalReceiverDelegate.containsAddress(erc777.address)).toBeTruthy();
       expect(
-        await universalReceiverDelegate.containsAddress(digitalCertificate.address)
+        await universalReceiverDelegate.containsAddress(erc777.address)
+      ).toBeTruthy();
+      expect(
+        await universalReceiverDelegate.containsAddress(
+          digitalCertificate.address
+        )
       ).toBeTruthy();
     });
 
     it("Transfer from ERC777 and LSP4 to account and delegate to UniversalReceiverAddressStore", async () => {
       const owner = accounts[2];
-      const account: UniversalReceiverAddressStore = await new UniversalProfile__factory(
-        owner
-      ).deploy(owner.address);
-      const universalReceiverDelegate = await new UniversalReceiverAddressStore__factory(
-        owner
-      ).deploy(account.address);
+      const account: UniversalReceiverAddressStore =
+        await new UniversalProfile__factory(owner).deploy(owner.address);
+      const universalReceiverDelegate =
+        await new UniversalReceiverAddressStore__factory(owner).deploy(
+          account.address
+        );
 
       // set account2 as new receiver for account1
       await account
@@ -715,12 +850,19 @@ describe("UniversalProfile", () => {
 
       let tokenOwner = accounts[3];
 
-      let erc777: ERC777UniversalReceiver = await new ERC777UniversalReceiver__factory(
-        owner
-      ).deploy("MyToken", "TKN", [tokenOwner.address]);
-      let digitalCertificate: LSP4DigitalCertificate = await new LSP4DigitalCertificate__factory(
-        owner
-      ).deploy(tokenOwner.address, "MyDigitalCloth", "DIGICLOTH01", []);
+      let erc777: ERC777UniversalReceiver =
+        await new ERC777UniversalReceiver__factory(owner).deploy(
+          "MyToken",
+          "TKN",
+          [tokenOwner.address]
+        );
+      let digitalCertificate: LSP4DigitalCertificate =
+        await new LSP4DigitalCertificate__factory(owner).deploy(
+          tokenOwner.address,
+          "MyDigitalCloth",
+          "DIGICLOTH01",
+          []
+        );
 
       await erc777.connect(tokenOwner).mint(account.address, "100");
       await digitalCertificate.connect(tokenOwner).mint(account.address, "100");
@@ -729,36 +871,53 @@ describe("UniversalProfile", () => {
       expect(await digitalCertificate.balanceOf(account.address)).toEqBN(100);
 
       let abi;
-      abi = erc777.interface.encodeFunctionData("send", [accounts[4].address, "50", "0x"]);
+      abi = erc777.interface.encodeFunctionData("send", [
+        accounts[4].address,
+        "50",
+        "0x",
+      ]);
       await account
         .connect(owner)
-        .execute(OPERATIONS.CALL, erc777.address, 0, abi, { gasLimit: 3_000_000 });
-      abi = erc777.interface.encodeFunctionData("transfer", [accounts[4].address, "50"]);
+        .execute(OPERATIONS.CALL, erc777.address, 0, abi, {
+          gasLimit: 3_000_000,
+        });
+      abi = erc777.interface.encodeFunctionData("transfer", [
+        accounts[4].address,
+        "50",
+      ]);
       await account
         .connect(owner)
-        .execute(OPERATIONS.CALL, erc777.address, 0, abi, { gasLimit: 3_000_000 });
+        .execute(OPERATIONS.CALL, erc777.address, 0, abi, {
+          gasLimit: 3_000_000,
+        });
 
       abi = digitalCertificate.interface.encodeFunctionData("send", [
         accounts[4].address,
         "50",
         "0x",
       ]);
-      await account.connect(owner).execute(OPERATIONS.CALL, digitalCertificate.address, 0, abi, {
-        gasLimit: 3_000_000,
-      });
+      await account
+        .connect(owner)
+        .execute(OPERATIONS.CALL, digitalCertificate.address, 0, abi, {
+          gasLimit: 3_000_000,
+        });
       abi = digitalCertificate.interface.encodeFunctionData("transfer", [
         accounts[4].address,
         "50",
       ]);
-      await account.connect(owner).execute(OPERATIONS.CALL, digitalCertificate.address, 0, abi, {
-        gasLimit: 3_000_000,
-      });
+      await account
+        .connect(owner)
+        .execute(OPERATIONS.CALL, digitalCertificate.address, 0, abi, {
+          gasLimit: 3_000_000,
+        });
 
       expect(await erc777.balanceOf(account.address)).toEqBN(0);
       expect(await digitalCertificate.balanceOf(account.address)).toEqBN(0);
 
       expect(await erc777.balanceOf(accounts[4].address)).toEqBN(100);
-      expect(await digitalCertificate.balanceOf(accounts[4].address)).toEqBN(100);
+      expect(await digitalCertificate.balanceOf(accounts[4].address)).toEqBN(
+        100
+      );
     });
   }); //Context Universal Receiver
 
@@ -775,27 +934,42 @@ describe("UniversalProfile", () => {
       owner = accounts[6];
       signer = accounts[7];
       thirdParty = accounts[8];
-      UniversalProfile = await new UniversalProfile__factory(owner).deploy(owner.address);
-      keyManager = await new LSP6KeyManager__factory(owner).deploy(UniversalProfile.address);
+      UniversalProfile = await new UniversalProfile__factory(owner).deploy(
+        owner.address
+      );
+      keyManager = await new LSP6KeyManager__factory(owner).deploy(
+        UniversalProfile.address
+      );
 
       // give all permissions to owner
       await UniversalProfile.connect(owner).setData(
-        [ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + owner.address.substr(2)],
+        [
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
+            owner.address.substr(2),
+        ],
         [ALL_PERMISSIONS_SET]
       );
 
       // give SIGN permission to signer
       await UniversalProfile.connect(owner).setData(
-        [ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + signer.address.substr(2)],
+        [
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
+            signer.address.substr(2),
+        ],
         [ethers.utils.hexZeroPad(PERMISSIONS.SIGN, 32)]
       );
       // give CALL permission to non-signer
       await UniversalProfile.connect(owner).setData(
-        [ERC725YKeys.LSP6["AddressPermissions:Permissions:"] + thirdParty.address.substr(2)],
+        [
+          ERC725YKeys.LSP6["AddressPermissions:Permissions:"] +
+            thirdParty.address.substr(2),
+        ],
         ["0x08"]
       );
 
-      await UniversalProfile.connect(owner).transferOwnership(keyManager.address);
+      await UniversalProfile.connect(owner).transferOwnership(
+        keyManager.address
+      );
     });
 
     it("Accounts should have owner as KeyManager", async () => {
@@ -809,7 +983,10 @@ describe("UniversalProfile", () => {
         const messageHash = ethers.utils.hashMessage(dataToSign);
         const signature = await owner.signMessage(dataToSign);
 
-        const result = await keyManager.callStatic.isValidSignature(messageHash, signature);
+        const result = await keyManager.callStatic.isValidSignature(
+          messageHash,
+          signature
+        );
         expect(result).toEqual(ERC1271.MAGIC_VALUE);
       });
 
@@ -818,7 +995,10 @@ describe("UniversalProfile", () => {
         const messageHash = ethers.utils.hashMessage(dataToSign);
         const signature = await signer.signMessage(dataToSign);
 
-        const result = await keyManager.callStatic.isValidSignature(messageHash, signature);
+        const result = await keyManager.callStatic.isValidSignature(
+          messageHash,
+          signature
+        );
         expect(result).toEqual(ERC1271.MAGIC_VALUE);
       });
 
@@ -827,7 +1007,10 @@ describe("UniversalProfile", () => {
         const messageHash = ethers.utils.hashMessage(dataToSign);
         const signature = await thirdParty.signMessage(dataToSign);
 
-        const result = await keyManager.callStatic.isValidSignature(messageHash, signature);
+        const result = await keyManager.callStatic.isValidSignature(
+          messageHash,
+          signature
+        );
         expect(result).toEqual(ERC1271.FAIL_VALUE);
       });
     });
@@ -858,7 +1041,9 @@ describe("UniversalProfile", () => {
       await keyManager.connect(owner).execute(abi);
 
       const destBalanceFinal = await provider.getBalance(dest.address);
-      const idBalanceFinal = await provider.getBalance(UniversalProfile.address);
+      const idBalanceFinal = await provider.getBalance(
+        UniversalProfile.address
+      );
       const managerBalanceFinal = await provider.getBalance(keyManager.address);
 
       expect(managerBalance).toEqual(managerBalanceFinal); // "manager balance shouldn't have changed"


### PR DESCRIPTION
# What does this PR introduce

This PR was introduced based on a discussion from #82 

**Contracts**

- use hardcoded constants for ERC165 interface identifiers.

**Tests**

- replace occurences of interfaceIDs literals in test files with reference to `constants.ts` file.