### PR TITLE
ci: readd android build and release steps

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -30,26 +30,25 @@ jobs:
 
       - run: npm ci
 
-      # Temporarily removing Android steps. Web3J installation script is broken, see https://github.com/web3j/web3j/issues/1579
       # Android artifacts
 
-      # - name: Install Web3j
-      #   run: curl -L get.web3j.io | sh && source ~/.web3j/source.sh
+      - name: Install Web3j
+        run: curl -L get.web3j.io | sh && source ~/.web3j/source.sh
 
-      # - name: Generate Android artifacts
-      #   run: npx ts-node make-android.ts
+      - name: Generate Android artifacts
+        run: npx ts-node make-android.ts
 
-      # - name: Set up our JDK environment
-      #   uses: actions/setup-java@v1.4.3
-      #   with:
-      #     java-version: 1.11
+      - name: Set up our JDK environment
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 1.11
 
-      # - name: Grant rights
-      #   run: chmod +x java/build.gradle
+      - name: Grant rights
+        run: chmod +x java/build.gradle
 
-      # - name: Build jar
-      #   working-directory: ./java
-      #   run: gradle build
+      - name: Build jar
+        working-directory: ./java
+        run: gradle build
 
       # iOS artifacts
       - name: Generate iOS artifacts
@@ -65,12 +64,12 @@ jobs:
           name: UPContractsAbi.swift
           path: ios/UPContractsAbi.swift
 
-      # - name: Upload Android Artifact
-      #   uses: actions/upload-artifact@v2
-      #   if: github.event_name == 'push'  && steps.check.outputs.changed == 'true'
-      #   with:
-      #     name: upcontracts.jar
-      #     path: java/build/libs/upcontracts.jar 
+      - name: Upload Android Artifact
+        uses: actions/upload-artifact@v2
+        if: github.event_name == 'push'  && steps.check.outputs.changed == 'true'
+        with:
+          name: upcontracts.jar
+          path: java/build/libs/upcontracts.jar 
 
       # Trigger Release
       - name: Repository Dispatch

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -32,17 +32,16 @@ jobs:
           git tag -a ${{ env.APP_VERSION }} -m "Release Version ${{ env.APP_VERSION }}"
           git push --set-upstream origin develop tag ${{ env.APP_VERSION }}
 
-      # Temporarily removing Android steps. Web3J installation script is broken, see https://github.com/web3j/web3j/issues/1579
       # Android artifacts
-      # - name: Download artifact
-      #   uses: dawidd6/action-download-artifact@v2
-      #   with: 
-      #     workflow: build-artifacts.yml
-      #     workflow_conclusion: success
-      #     name: upcontracts.jar
-      #     path: java/build/libs
-      #     branch: main
-      #     event: push
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with: 
+          workflow: build-artifacts.yml
+          workflow_conclusion: success
+          name: upcontracts.jar
+          path: java/build/libs
+          branch: main
+          event: push
 
       # iOS artifacts
       - name: Download artifact

--- a/.github/workflows/publish-android-artifacts.yml
+++ b/.github/workflows/publish-android-artifacts.yml
@@ -11,23 +11,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Temporarily removing Android steps. Web3J installation script is broken, see https://github.com/web3j/web3j/issues/1579
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with: 
+          workflow: build-artifacts.yml
+          workflow_conclusion: success
+          name: upcontracts.jar
+          path: java/build/libs
+          branch: main
+          event: push
 
-      # - name: Download artifact
-      #   uses: dawidd6/action-download-artifact@v2
-      #   with: 
-      #     workflow: build-artifacts.yml
-      #     workflow_conclusion: success
-      #     name: upcontracts.jar
-      #     path: java/build/libs
-      #     branch: main
-      #     event: push
-
-      # - name: Publish jar
-      #   working-directory: ./java
-      #   run: gradle publish
-      #   env:
-      #     # https://github.com/actions/setup-node/issues/49
-      #     # Have to use my personal access token until the issue is resolved
-      #     GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
-      #     GITHUB_ACTOR: ${{ secrets.PERSONAL_ACTOR }}
+      - name: Publish jar
+        working-directory: ./java
+        run: gradle publish
+        env:
+          # https://github.com/actions/setup-node/issues/49
+          # Have to use my personal access token until the issue is resolved
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GITHUB_ACTOR: ${{ secrets.PERSONAL_ACTOR }}


### PR DESCRIPTION
Android build steps were temporary removed as Web3J installation was broken. Web3J installation is now fixed so can add android steps back. See https://github.com/web3j/web3j/issues/1579